### PR TITLE
refs #510: header nodes in Aloha should not have @class on input.

### DIFF
--- a/rhaptos/cnxmlutils/xsl/aloha-to-html5-pass04-headers2sections.xsl
+++ b/rhaptos/cnxmlutils/xsl/aloha-to-html5-pass04-headers2sections.xsl
@@ -80,14 +80,12 @@ Output:
       <xsl:attribute name="data-label"><xsl:value-of select="@data-label"/></xsl:attribute>
     </xsl:if>
     <xsl:element name="h{@level}">
+      <xsl:attribute name="class">title</xsl:attribute>
       <xsl:if test="@data-header-id">
         <xsl:attribute name="id"><xsl:value-of select="@data-header-id"/></xsl:attribute>
       </xsl:if>
       <xsl:if test="@data-header-class">
         <xsl:attribute name="data-class"><xsl:value-of select="@data-header-class"/></xsl:attribute>
-      </xsl:if>
-      <xsl:if test="@class">
-        <xsl:attribute name="class"><xsl:value-of select="@class"/></xsl:attribute>
       </xsl:if>
       <xsl:value-of select="@title"/>
     </xsl:element>

--- a/rhaptos/cnxmlutils/xsl/html5-to-aloha.xsl
+++ b/rhaptos/cnxmlutils/xsl/html5-to-aloha.xsl
@@ -92,10 +92,6 @@ Log:
         <xsl:value-of select="@id"/>
       </xsl:attribute>
     </xsl:if>
-    <xsl:if test="@class">
-      <!-- here is hoping section/@class does not exist -->
-      <xsl:apply-templates select="@class" />
-    </xsl:if>
     <xsl:if test="@data-class">
       <xsl:attribute name="data-header-class">
         <xsl:value-of select="@data-class"/>


### PR DESCRIPTION
<h* class="title"> was causing issues in Aloha (and is a bit redundant), so we remove class="title" from structure to aloha html conversion and add it back on aloha to structure html conversion.
