### PR TITLE
m:* also covers m:math. Remove extra m:math handling

### DIFF
--- a/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
+++ b/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
@@ -65,13 +65,6 @@
 </xsl:template>
 
 <!-- MathJax doesn't like MathML with a prefix -->
-<xsl:template match="m:math">
-  <xsl:element name="{local-name()}">
-    <xsl:attribute name="xmlns">http://www.w3.org/1998/Math/MathML</xsl:attribute>
-    <xsl:apply-templates select="@*|node()"/>
-  </xsl:element>
-</xsl:template>
-
 <xsl:template match="m:*">
   <xsl:element name="{local-name()}" namespaceURI="http://www.w3.org/1998/Math/MathML">
     <xsl:apply-templates select="@*|node()"/>


### PR DESCRIPTION
namespace declaration with an attribute can cause problems. m:\* also covers m:math. It seems in the past only m:math was given a new namespace but this did not included the children this is why a m:\* template was added.
