### PR TITLE
Create a <img> tag for cnxml images with print-width

### DIFF
--- a/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
+++ b/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
@@ -459,7 +459,7 @@
 </xsl:template>
 
 <xsl:template match="c:image/@src|c:image/@mime-type|c:image/@for"/>
-<xsl:template match="c:image[not(@print-width or @thumbnail or @longdesc or @for='pdf')]">
+<xsl:template match="c:image[not(@thumbnail or @longdesc or @for='pdf')]">
   <img src="{@src}" data-media-type="{@mime-type}">
     <xsl:if test="parent::c:media[@alt]">
       <xsl:attribute name="alt">
@@ -469,11 +469,16 @@
     <xsl:apply-templates select="@*|node()"/>
   </img>
 </xsl:template>
-<xsl:template match="c:image[not(@print-width or @thumbnail or @longdesc) and @for='pdf']">
+<xsl:template match="c:image[not(@thumbnail or @longdesc) and @for='pdf']">
   <span data-media-type="{@mime-type}" data-print="true" data-src="{@src}">
     <xsl:apply-templates select="@*|node()"/>
     <xsl:comment> </xsl:comment> <!-- do not make span self closing when no children -->
   </span>
+</xsl:template>
+<xsl:template match="c:image/@print-width">
+  <xsl:attribute name="data-print-width">
+    <xsl:value-of select="." />
+  </xsl:attribute>
 </xsl:template>
 <xsl:template match="c:image/@width|c:image/@height">
   <xsl:copy/>


### PR DESCRIPTION
Should fix https://github.com/Connexions/cnx-upgrade/issues/29

Much of our content that was imported from word has print-width.
