### PR TITLE
add support for c:list/@list-type="labeled-item"

### DIFF
--- a/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
+++ b/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
@@ -296,7 +296,7 @@
 <!-- Discard these attributes because they are converted in some other way or deprecated -->
 <xsl:template match="c:list/@list-type"/>
 
-<xsl:template match="c:list[c:title][not(@list-type) or @list-type='bulleted' or @list-type='enumerated']">
+<xsl:template match="c:list[c:title]">
   <div><!-- list-id-and-class will give it the class "list" at least -->
     <xsl:call-template name="list-id-and-class"/>
     <xsl:apply-templates select="c:title"/>
@@ -306,7 +306,7 @@
   </div>
 </xsl:template>
 
-<xsl:template match="c:para//c:list[c:title][not(@list-type) or @list-type='bulleted' or @list-type='enumerated']">
+<xsl:template match="c:para//c:list[c:title]">
   <span><!-- list-id-and-class will give it the class "list" at least -->
     <xsl:call-template name="list-id-and-class"/>
     <xsl:apply-templates select="c:title"/>
@@ -316,7 +316,7 @@
   </span>
 </xsl:template>
 
-<xsl:template match="c:list[not(c:title)][not(@list-type) or @list-type='bulleted' or @list-type='enumerated']">
+<xsl:template match="c:list[not(c:title)]">
   <xsl:apply-templates mode="list-mode" select=".">
     <xsl:with-param name="convert-id-and-class" select="1"/>
   </xsl:apply-templates>
@@ -334,6 +334,17 @@
     </xsl:if>
     <xsl:apply-templates select="@*['id' != local-name()]|node()[not(self::c:title)]"/>
   </ol>
+</xsl:template>
+
+<!-- lists marked as having labeled items have a boolean attribute so the CSS can have `list-style-type:none` -->
+<xsl:template mode="list-mode" match="c:list[@list-type='labeled-item']">
+  <xsl:param name="convert-id-and-class"/>
+  <ul data-labeled-item="true">
+    <xsl:if test="$convert-id-and-class">
+      <xsl:call-template name="list-id-and-class"/>
+    </xsl:if>
+    <xsl:apply-templates select="@*['id' != local-name()]|node()[not(self::c:title)]"/>
+  </ul>
 </xsl:template>
 
 <xsl:template mode="list-mode" match="c:list[not(@list-type) or @list-type='bulleted']">

--- a/rhaptos/cnxmlutils/xsl/test/list.cnxml
+++ b/rhaptos/cnxmlutils/xsl/test/list.cnxml
@@ -100,11 +100,9 @@
 
     <section><title>Labeled-Item list:</title>
 
-      <para>This should not be implemented yet</para>
-
-      <list list-type="labeled-item">
-        <item>and item</item>
-      </list>
+    <list list-type="labeled-item" id="id1">
+      <item><label>with a label</label> and item</item>
+    </list>
 
     </section>
 
@@ -209,10 +207,8 @@
 
   <section><title>Labeled-Item list:</title>
 
-    <para>This should not be implemented yet</para>
-
     <para>...<list list-type="labeled-item" id="id1">
-      <item>and item</item>
+      <item><label>with a label</label> and item</item>
     </list>...</para>
 
   </section>

--- a/rhaptos/cnxmlutils/xsl/test/list.html
+++ b/rhaptos/cnxmlutils/xsl/test/list.html
@@ -88,11 +88,9 @@
 
     <section data-depth="2"><h2 class="title">Labeled-Item list:</h2>
 
-      <p class="para">This should not be implemented yet</p>
-
-      <div class="not-converted-yet">NOT_CONVERTED_YET: list</div><list xmlns="http://cnx.rice.edu/cnxml">
-        <li xmlns="" class="item">and item</li>
-      </list>
+    <ul data-labeled-item="true" class="list" id="id1">
+      <li class="item" data-label="with a label"> and item</li>
+    </ul>
 
     </section>
 
@@ -190,11 +188,9 @@
 
   <section data-depth="2"><h2 class="title">Labeled-Item list:</h2>
 
-    <p class="para">This should not be implemented yet</p>
-
-    <p class="para">...<div class="not-converted-yet">NOT_CONVERTED_YET: list</div><list xmlns="http://cnx.rice.edu/cnxml" id="id1">
-      <li xmlns="" class="item">and item</li>
-    </list>...</p>
+    <p class="para">...<ul data-labeled-item="true" class="list" id="id1">
+      <li class="item" data-label="with a label"> and item</li>
+    </ul>...</p>
 
   </section>
 


### PR DESCRIPTION
CSS Note: the labels are in the `@data-label` attribute to be consistent with how we do labels elsewhere. They can be displayed with a `ul[data-labeled-item] > li[data-label]::before { content: attr(data-label); }` in CSS
