### PR TITLE
add support for c:emphasis effect="Bold"

### DIFF
--- a/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
+++ b/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
@@ -364,7 +364,7 @@
 
 <!-- ========================= -->
 
-<xsl:template match="c:emphasis[not(@effect) or @effect='bold']">
+<xsl:template match="c:emphasis[not(@effect) or @effect='bold' or @effect='Bold']">
   <strong><xsl:apply-templates mode="class" select="."/><xsl:apply-templates select="@*|node()"/></strong>
 </xsl:template>
 


### PR DESCRIPTION
Uggh, can we please do some data scrubbing before we switch to HTML as the canonical format? Like when `c:emphasis/text() == text()`? Entire links, captions, etc are all emphasized...
