### PR TITLE
Convert <newline> inside <item> and <newline effect="normal"> inside <para>

### DIFF
--- a/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
+++ b/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
@@ -710,7 +710,9 @@
 </xsl:template>
 
 
-<xsl:template match="c:newline[not(ancestor::c:para or ancestor::c:list)][not(@effect) or @effect = 'underline' or @effect = 'normal']">
+<xsl:template match="c:newline[not(parent::c:list)]
+                              [not(ancestor::c:para and @effect = 'underline')]
+                              [not(@effect) or @effect = 'underline' or @effect = 'normal']">
   <div class="newline">
     <xsl:apply-templates select="@*"/>
 

--- a/rhaptos/cnxmlutils/xsl/test/newline.cnxml
+++ b/rhaptos/cnxmlutils/xsl/test/newline.cnxml
@@ -13,6 +13,10 @@
   <newline id="id456" effect="underline"/>
   <newline effect="underline" count="3"/>
   <newline id="id789" effect="underline" count="3"/>
+  <para><newline/></para>
+  <list>
+    <item><newline/><newline effect="underline"/></item>
+  </list>
 
 
   <para>
@@ -27,7 +31,8 @@
   </para>
 
   <para>The following is not implemented yet</para>
-  <para><newline/></para>
+  <para><newline effect="underline"/></para>
+  <list><newline/></list>
 
 </content>
 </document>

--- a/rhaptos/cnxmlutils/xsl/test/newline.html
+++ b/rhaptos/cnxmlutils/xsl/test/newline.html
@@ -8,6 +8,10 @@
   <div class="newline" id="id456" data-effect="underline"><hr/></div>
   <div class="newline" data-effect="underline" data-count="3"><hr/><hr/><hr/></div>
   <div class="newline" id="id789" data-effect="underline" data-count="3"><hr/><hr/><hr/></div>
+  <p class="para"><div class="newline"><br/></div></p>
+  <ul class="list">
+    <li class="item"><div class="newline"><br/></div><div class="newline" data-effect="underline"><hr/></div></li>
+  </ul>
 
 
   <p class="para">
@@ -22,6 +26,7 @@
   </p>
 
   <p class="para">The following is not implemented yet</p>
-  <p class="para"><div class="not-converted-yet">NOT_CONVERTED_YET: newline</div><newline xmlns="http://cnx.rice.edu/cnxml"/></p>
+  <p class="para"><div class="not-converted-yet">NOT_CONVERTED_YET: newline</div><newline xmlns="http://cnx.rice.edu/cnxml" data-effect="underline"/></p>
+  <ul class="list"><div class="not-converted-yet">NOT_CONVERTED_YET: newline</div><newline xmlns="http://cnx.rice.edu/cnxml"/></ul>
 
 </body>


### PR DESCRIPTION
<newline effect="underline"/> inside a <para> results in invalid HTML.
I don't know if we should convert it anyway or not.  Right now we'll get
"NOT_CONVERTED_YET".

I tried it on the index.cnxml of the example that Ed gave http://desert.cnx.rice.edu/contents/fe05a681-fab0-48f0-be12-db6a8eb05aaa:6 and it now transforms all the `<newline/>`s.
