### PR TITLE
move c:figure/c:title out of figcaption

### DIFF
--- a/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
+++ b/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
@@ -158,7 +158,7 @@
   </div>
 </xsl:template>
 
-<xsl:template match="c:para/c:title|c:table/c:title|c:para//c:list/c:title">
+<xsl:template match="c:para/c:title|c:table/c:title|c:para//c:title">
   <span><xsl:apply-templates mode="class" select="."/><xsl:apply-templates select="@*|node()"/></span>
 </xsl:template>
 
@@ -545,16 +545,17 @@
   <xsl:call-template name="data-prefix"/>
 </xsl:template>
 
+<xsl:template match="c:figure/c:caption">
+  <figcaption>
+    <xsl:apply-templates select="@*|node()"/>
+  </figcaption>
+</xsl:template>
+
 <xsl:template match="c:figure|c:subfigure">
   <figure>
     <xsl:apply-templates select="@*|c:label"/>
-    <xsl:if test="c:caption or c:title">
-      <figcaption>
-        <xsl:apply-templates select="c:title"/>
-        <!-- NOTE: caption loses the optional id -->
-        <xsl:apply-templates select="c:caption/node()"/>
-      </figcaption>
-    </xsl:if>
+    <xsl:apply-templates select="c:title"/>
+    <xsl:apply-templates select="c:caption"/>
     <xsl:apply-templates select="node()[not(self::c:title or self::c:caption or self::c:label)]"/>
   </figure>
 </xsl:template>

--- a/rhaptos/cnxmlutils/xsl/test/figure.cnxml
+++ b/rhaptos/cnxmlutils/xsl/test/figure.cnxml
@@ -1,0 +1,34 @@
+<document xmlns="http://cnx.rice.edu/cnxml" xmlns:md="http://cnx.rice.edu/mdml/0.4" xmlns:bib="http://bibtexml.sf.net/" xmlns:q="http://cnx.rice.edu/qml/1.0" xmlns:md1="http://cnx.rice.edu/mdml" cnxml-version="0.7">
+  <title>Test Module</title>
+<metadata xmlns:md="http://cnx.rice.edu/mdml" mdml-version="0.5">
+</metadata>
+
+<content>
+
+  <figure>
+    <span>Text</span>
+  </figure>
+
+  <figure>
+    <label>Label</label>
+    <title>Title</title>
+    <span>Text</span>
+    <caption>Caption</caption>
+  </figure>
+
+  <figure id="id123" orient="vertical" type="foo">
+    <span>Text</span>
+  </figure>
+
+
+  <para>Inside a para (make sure the title is a span, not a div):
+    <figure>
+      <label>Label</label>
+      <title>Title</title>
+      <span>Text</span>
+      <caption>Caption</caption>
+    </figure>
+  </para>
+
+</content>
+</document>

--- a/rhaptos/cnxmlutils/xsl/test/figure.html
+++ b/rhaptos/cnxmlutils/xsl/test/figure.html
@@ -1,0 +1,24 @@
+<body xmlns:c="http://cnx.rice.edu/cnxml" xmlns:md="http://cnx.rice.edu/mdml" xmlns:qml="http://cnx.rice.edu/qml/1.0" xmlns:mod="http://cnx.rice.edu/#moduleIds" xmlns:bib="http://bibtexml.sf.net/" xmlns:data="http://dev.w3.org/html5/spec/#custom"><div class="title">Test Module</div>
+
+  <figure>
+    <span>Text</span>
+  </figure>
+
+  <figure data-label="Label"><div class="title">Title</div><figcaption>Caption</figcaption>
+    <span>Text</span>
+    
+  </figure>
+
+  <figure id="id123" data-orient="vertical" data-type="foo">
+    <span>Text</span>
+  </figure>
+
+
+  <p class="para">Inside a para (make sure the title is a span, not a div):
+    <figure data-label="Label"><span class="title">Title</span><figcaption>Caption</figcaption>
+      <span>Text</span>
+      
+    </figure>
+  </p>
+
+</body>


### PR DESCRIPTION
This will require additional CSS for the figure title `figure > .title` (and note the title may be a span if the figure is inline)
