### PR TITLE
add support for c:list/c:label[*] and just use the text

### DIFF
--- a/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
+++ b/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
@@ -144,9 +144,12 @@
   <xsl:attribute name="data-label"><xsl:value-of select="node()"/></xsl:attribute>
 </xsl:template>
 
+<!-- TODO: revisit whether labels should contain markup or if the markup can be "pushed" out; some contain emphasis and math -->
 <xsl:template match="c:label[*]">
   <xsl:message>TODO: Support label with element children</xsl:message>
-  <div class="not-converted-yet">NOT_CONVERTED_YET: Support label with element children</div>
+  <xsl:attribute name="data-label">
+    <xsl:apply-templates select="text()|.//c:*/text()"/> <!-- do not include MathML text nodes -->
+  </xsl:attribute>
 </xsl:template>
 
 <!-- ========================= -->

--- a/rhaptos/cnxmlutils/xsl/test/label.cnxml
+++ b/rhaptos/cnxmlutils/xsl/test/label.cnxml
@@ -1,0 +1,23 @@
+<document xmlns="http://cnx.rice.edu/cnxml" xmlns:md="http://cnx.rice.edu/mdml/0.4" xmlns:bib="http://bibtexml.sf.net/" xmlns:q="http://cnx.rice.edu/qml/1.0" xmlns:md1="http://cnx.rice.edu/mdml" cnxml-version="0.7">
+  <title>Test Module</title>
+<metadata xmlns:md="http://cnx.rice.edu/mdml" mdml-version="0.5">
+</metadata>
+
+<content>
+
+  <list>
+    <item>
+      <label>label</label>
+      item
+    </item>
+  </list>
+
+  <list>
+    <item>
+      <label>hello <emphasis>there</emphasis></label>
+      item
+    </item>
+  </list>
+
+</content>
+</document>

--- a/rhaptos/cnxmlutils/xsl/test/label.html
+++ b/rhaptos/cnxmlutils/xsl/test/label.html
@@ -1,0 +1,15 @@
+<body xmlns:c="http://cnx.rice.edu/cnxml" xmlns:md="http://cnx.rice.edu/mdml" xmlns:qml="http://cnx.rice.edu/qml/1.0" xmlns:mod="http://cnx.rice.edu/#moduleIds" xmlns:bib="http://bibtexml.sf.net/" xmlns:data="http://dev.w3.org/html5/spec/#custom"><div class="title">Test Module</div>
+
+  <ul class="list">
+    <li class="item" data-label="label">
+      item
+    </li>
+  </ul>
+
+  <ul class="list">
+    <li class="item" data-label="hello there">
+      item
+    </li>
+  </ul>
+
+</body>


### PR DESCRIPTION
This does drop the label inside the image. We should revisit labels with markup.
