### PR TITLE
Ignore <label> inside <note> in cnxml to html transform

### DIFF
--- a/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
+++ b/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
@@ -292,6 +292,9 @@
   </xsl:attribute>
 </xsl:template>
 
+<xsl:template match="c:note/c:label">
+</xsl:template>
+
 <xsl:template match="c:note">
   <div>
     <xsl:apply-templates mode="class" select="."/>


### PR DESCRIPTION
This attempts to fix the following error:

runtime error: file
/home/karen/rhaptos.cnxmlutils/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
line 144 element attribute
xsl:attribute: Cannot add attributes to an element if children have been
already added to the element.

When we transform http://cnx.org/content/m46882/latest/index.cnxml
