### PR TITLE
Transform youtube videos and videos not supported by html5 video tag

### DIFF
--- a/rhaptos/cnxmlutils/tests/data/media-video.cnxml
+++ b/rhaptos/cnxmlutils/tests/data/media-video.cnxml
@@ -24,5 +24,24 @@
       </figure> 
     </para>
 
+    <para id="para-3">
+      <figure id="fig-3">
+        <media id="test_media_video_youtube" alt="alt text">
+          <video mime-type="application/x-shockwave-flash" src="http://www.youtube.com/v/k9oSQNTHUZM"/>
+        </media>
+        <media id="test_media_video_youtube_2" alt="alt text">
+          <video mime-type="video/mpeg" src="http://www.youtube.com/embed/r-FonWBEb0o" autoplay="false" width="320" height="260"/>
+        </media>
+      </figure>
+    </para>
+
+    <para id="para-4">
+      <figure id="fig-4">
+        <media id="test_media_video_quicktime" alt="alt text">
+          <video mime-type="video/quicktime" src="http://dev.cnx.org/resources/659920df8c48f27d0f46b14c1f495dea" height="300"/>
+        </media>
+      </figure>
+    </para>
+
   </content>
 </document>

--- a/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
+++ b/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
@@ -775,12 +775,29 @@
   </audio>
 </xsl:template>
 
-<xsl:template match="c:video">
+<xsl:template match="c:video[contains(@src, 'youtube')]">
+  <iframe type="text/html" frameborder="0" src="{@src}" width="640" height="390">
+    <xsl:apply-templates select="@width|@height"/>
+  </iframe>
+</xsl:template>
+
+<xsl:template match="c:video[@mime-type='video/mp4' or @mimetype='video/ogg' or @mimetype='video/webm']">
   <video controls="controls">
     <xsl:apply-templates select="@*|c:param"/>
     <source src="{@src}" type="{@mime-type}"/>
     <xsl:apply-templates select="node()[not(self::c:param)]"/>
   </video>
+</xsl:template>
+
+<xsl:template match="c:video">
+  <object width="640" height="400">
+    <xsl:apply-templates select="@*|c:param"/>
+    <param name="src" value="{@src}"/>
+    <xsl:apply-templates select="node()[not(self::c:param)]"/>
+    <embed src="{@src}" type="{@mime-type}" width="640" height="400">
+      <xsl:apply-templates select="@width|@height"/>
+    </embed>
+  </object>
 </xsl:template>
 
 <!-- ===================== -->


### PR DESCRIPTION
- embed youtube videos using iframes
- transform videos that are not "video/mp4", "video/ogg" and
  "video/webm" to embed tags (like legacy)
