### PR TITLE
Transform elements with titles to sections

### DIFF
--- a/rhaptos/cnxmlutils/tests/data/titles.cnxml
+++ b/rhaptos/cnxmlutils/tests/data/titles.cnxml
@@ -1,4 +1,4 @@
-<document xmlns="http://cnx.rice.edu/cnxml" xmlns:md="http://cnx.rice.edu/mdml/0.4" xmlns:bib="http://bibtexml.sf.net/" xmlns:q="http://cnx.rice.edu/qml/1.0" xmlns:md1="http://cnx.rice.edu/mdml" id="id1164845029421" module-id="m12345" cnxml-version="0.7">
+<document xmlns="http://cnx.rice.edu/cnxml" xmlns:md="http://cnx.rice.edu/mdml/0.4" xmlns:bib="http://bibtexml.sf.net/" xmlns:q="http://cnx.rice.edu/qml/1.0" xmlns:md1="http://cnx.rice.edu/mdml" xmlns:m="http://www.w3.org/1998/Math/MathML" id="id1164845029421" module-id="m12345" cnxml-version="0.7">
 <content>
 
   <section id="sectioned-section">
@@ -113,6 +113,136 @@ __enable_interrupt();
       </code>
       <!-- no c:preformat/c:title records exist in connextions-->
     </section>
+
+    <!-- m21405 // abef6f6b-bb16-49b2-a40a-fac28a96cfb2 -->
+    <quote id="quote-test">
+      <title>Sir Francis Bacon, 1623</title>
+      ...a man may express and signifie the intentions of his minde, at any distance... by... objects... capable of a twofold difference onely.
+    </quote>
+
+
+    <!-- m47370 // abc1d9ac-cf38-48a3-8fd0-6b8210949d9a -->
+    <equation id="equation-test">
+      <title>Discrete-Time Fourier Transform</title>
+      <m:math>
+        <m:apply>
+          <m:eq/>
+          <m:apply>
+            <m:ci type="fn" class="continuous">X</m:ci>
+            <m:ci>Ω</m:ci>
+          </m:apply>
+          <m:apply>
+            <m:sum/>
+            <m:bvar>
+              <m:ci>n</m:ci>
+            </m:bvar>
+            <m:lowlimit>
+              <m:apply>
+                <m:minus/>
+                <m:infinity/>
+              </m:apply>
+            </m:lowlimit>
+            <m:uplimit>
+              <m:infinity/>
+            </m:uplimit>
+            <m:apply>
+              <m:times/>
+              <m:apply>
+                <m:ci type="fn" class="discrete">f</m:ci>
+                <m:ci>n</m:ci>
+              </m:apply>
+              <m:apply>
+                <m:exp/>
+                <m:apply>
+                  <m:minus/>
+                  <m:apply>
+                    <m:times/>
+                    <m:ci>j</m:ci>
+                    <m:ci>Ω</m:ci>
+                    <m:ci>n</m:ci>
+                  </m:apply>
+                </m:apply>
+              </m:apply>
+            </m:apply>
+          </m:apply>
+        </m:apply>
+      </m:math>
+    </equation>
+
+    <!-- m46793 // cd6a0ee9-4ca0-4a1c-8498-0a26fa474fa1 -->
+    <figure id="figure-test">
+      <title>Intslación de GNU Octave 6.3.1</title>
+      <media id="id-mediaa" display="block" alt="Video">
+        <image src="example.png" mime-type="image/png"/>
+      </media>
+      <!-- m46185 // 3a3321e4-29e5-4709-a9f3-f9c342fe0127 -->
+      <subfigure id="subfigure-test">
+        <title>Zero Correlation</title>
+        <media id="id1165447908510" alt="Scatterplot of points in a horizontal configuration.">
+          <image src="example.png" mime-type="image/png" print-width="2in"/>
+        </media>
+      </subfigure>
+    </figure>
+
+    <!-- m47819 // d7397b20-8abb-40e4-b074-dc58e46b399c -->
+    <example id="example-test" type="listing">
+      <label>Listing</label>
+      <title>
+        <emphasis id="Listing_1" effect="bold"></emphasis>
+        Question 4.
+      </title>
+      <para> ... </para>
+    </example>
+
+    <!-- m42219 // 030347e9-f128-486f-a779-019ac474ff90 -->
+    <exercise id="exercise-test" type="check-understanding">
+      <label/>
+      <title>Check Your Understanding</title>
+      <!-- m31849 // fea36ff3-dc5d-43ee-ab74-f40da2a94c1a -->
+      <problem id="problem-test">
+        <title>Extra Credit Problem</title>
+        <para id="new1">
+          One extra credit point will be awarded to you and your partner if you can implement the dual-channel system without using the auxiliary registers
+          <code>AR0</code>
+          ,
+          <code>AR3</code>
+          , and
+          <code>AR5</code>
+          . Why is this more difficult? Renaming the registers using the
+          <code>.asg</code>
+          directive does not count!
+        </para>
+      </problem>
+      <!-- m46909 // cb418599-f69b-46c1-b0ef-60d9e36e677f -->
+      <solution id="solution-test" class="solutions">
+        <label/>
+        <title>Try It Solutions</title>
+        <para id="fs-idp54569968">
+          The
+          <emphasis>population</emphasis>
+          is all families with children attending Knoll Academy.
+        </para>
+      </solution>
+    </exercise>
+
+    <!-- No commentary/title found in the production cnx database. -->
+
+    <!-- No meaning/title found in the production cnx database. -->
+
+    <!-- m47353 // 7bc0c611-be01-4bcf-9e92-d3209d525828 -->
+    <rule id="rule-test" type="rule">
+      <title>Real Signals</title>
+      <statement id="statement-test">
+        <!-- m18908 // 3082636b-c837-4cf3-bae4-e3d9cbb19a00 -->
+        <title>Real Symmetry</title>
+        <para> ... </para>
+      </statement>
+      <proof id="proof-test">
+        <!-- m12849 // 5c38f888-5797-46ab-9d48-6b99d79281f1 -->
+        <title>Real Proof</title>
+        <para> ... </para>
+      </proof>
+    </rule>
 
   </content>
 </document>

--- a/rhaptos/cnxmlutils/tests/test_xsl_cnxml_to_html5.py
+++ b/rhaptos/cnxmlutils/tests/test_xsl_cnxml_to_html5.py
@@ -502,3 +502,165 @@ class CxnmlToHtmlTestCase(unittest.TestCase):
     @unittest.skip("No instances of //c:preformat[c:title] exist in cnx.org.")
     def test_preformat_w_title(self):
         pass
+
+    def test_quote_w_title(self):
+        """Verify conversion of //c:quote[c:title] to a section."""
+        cnxml = etree.parse(os.path.join(TEST_DATA_DIR, 'titles.cnxml'))
+        html = self.call_target(cnxml).getroot()
+
+        try:
+            elm = html.xpath("//*[@id='quote-test-section']")[0]
+        except IndexError:
+            transformed_html = etree.tostring(html)
+            self.fail("Failed to transform: \n" + transformed_html)
+        title_elm, note_elm = elm.getchildren()
+        self.assertEqual(title_elm.tag, 'h1')
+        self.assertEqual(title_elm.attrib['class'], 'title')
+
+    def test_equation_w_title(self):
+        """Verify conversion of //c:equation[c:title] to a section."""
+        cnxml = etree.parse(os.path.join(TEST_DATA_DIR, 'titles.cnxml'))
+        html = self.call_target(cnxml).getroot()
+
+        try:
+            elm = html.xpath("//*[@id='equation-test-section']")[0]
+        except IndexError:
+            transformed_html = etree.tostring(html)
+            self.fail("Failed to transform: \n" + transformed_html)
+        title_elm, note_elm = elm.getchildren()
+        self.assertEqual(title_elm.tag, 'h1')
+        self.assertEqual(title_elm.attrib['class'], 'title')
+
+    def test_figure_w_title(self):
+        """Verify conversion of //c:figure[c:title] to a section."""
+        cnxml = etree.parse(os.path.join(TEST_DATA_DIR, 'titles.cnxml'))
+        html = self.call_target(cnxml).getroot()
+
+        try:
+            elm = html.xpath("//*[@id='figure-test-section']")[0]
+        except IndexError:
+            transformed_html = etree.tostring(html)
+            self.fail("Failed to transform: \n" + transformed_html)
+        title_elm, note_elm = elm.getchildren()
+        self.assertEqual(title_elm.tag, 'h1')
+        self.assertEqual(title_elm.attrib['class'], 'title')
+
+    def test_subfigure_w_title(self):
+        """Verify conversion of //c:subfigure[c:title] to a section."""
+        cnxml = etree.parse(os.path.join(TEST_DATA_DIR, 'titles.cnxml'))
+        html = self.call_target(cnxml).getroot()
+
+        try:
+            elm = html.xpath("//*[@id='subfigure-test-section']")[0]
+        except IndexError:
+            transformed_html = etree.tostring(html)
+            self.fail("Failed to transform: \n" + transformed_html)
+        title_elm, note_elm = elm.getchildren()
+        self.assertEqual(title_elm.tag, 'h2')
+        self.assertEqual(title_elm.attrib['class'], 'title')
+
+    def test_example_w_title(self):
+        """Verify conversion of //c:example[c:title] to a section."""
+        cnxml = etree.parse(os.path.join(TEST_DATA_DIR, 'titles.cnxml'))
+        html = self.call_target(cnxml).getroot()
+
+        try:
+            elm = html.xpath("//*[@id='example-test-section']")[0]
+        except IndexError:
+            transformed_html = etree.tostring(html)
+            self.fail("Failed to transform: \n" + transformed_html)
+        title_elm, note_elm = elm.getchildren()
+        self.assertEqual(title_elm.tag, 'h1')
+        self.assertEqual(title_elm.attrib['class'], 'title')
+
+    def test_exercise_w_title(self):
+        """Verify conversion of //c:exercise[c:title] to a section."""
+        cnxml = etree.parse(os.path.join(TEST_DATA_DIR, 'titles.cnxml'))
+        html = self.call_target(cnxml).getroot()
+
+        try:
+            elm = html.xpath("//*[@id='exercise-test-section']")[0]
+        except IndexError:
+            transformed_html = etree.tostring(html)
+            self.fail("Failed to transform: \n" + transformed_html)
+        title_elm, note_elm = elm.getchildren()
+        self.assertEqual(title_elm.tag, 'h1')
+        self.assertEqual(title_elm.attrib['class'], 'title')
+
+    def test_problem_w_title(self):
+        """Verify conversion of //c:problem[c:title] to a section."""
+        cnxml = etree.parse(os.path.join(TEST_DATA_DIR, 'titles.cnxml'))
+        html = self.call_target(cnxml).getroot()
+
+        try:
+            elm = html.xpath("//*[@id='problem-test-section']")[0]
+        except IndexError:
+            transformed_html = etree.tostring(html)
+            self.fail("Failed to transform: \n" + transformed_html)
+        title_elm, note_elm = elm.getchildren()
+        self.assertEqual(title_elm.tag, 'h2')
+        self.assertEqual(title_elm.attrib['class'], 'title')
+
+    def test_solution_w_title(self):
+        """Verify conversion of //c:solution[c:title] to a section."""
+        cnxml = etree.parse(os.path.join(TEST_DATA_DIR, 'titles.cnxml'))
+        html = self.call_target(cnxml).getroot()
+
+        try:
+            elm = html.xpath("//*[@id='solution-test-section']")[0]
+        except IndexError:
+            transformed_html = etree.tostring(html)
+            self.fail("Failed to transform: \n" + transformed_html)
+        title_elm, note_elm = elm.getchildren()
+        self.assertEqual(title_elm.tag, 'h2')
+        self.assertEqual(title_elm.attrib['class'], 'title')
+
+    def test_rule_w_title(self):
+        """Verify conversion of //c:rule[c:title] to a section."""
+        cnxml = etree.parse(os.path.join(TEST_DATA_DIR, 'titles.cnxml'))
+        html = self.call_target(cnxml).getroot()
+
+        try:
+            elm = html.xpath("//*[@id='rule-test-section']")[0]
+        except IndexError:
+            transformed_html = etree.tostring(html)
+            self.fail("Failed to transform: \n" + transformed_html)
+        title_elm, note_elm = elm.getchildren()
+        self.assertEqual(title_elm.tag, 'h1')
+        self.assertEqual(title_elm.attrib['class'], 'title')
+
+    def test_statement_w_title(self):
+        """Verify conversion of //c:statement[c:title] to a section."""
+        cnxml = etree.parse(os.path.join(TEST_DATA_DIR, 'titles.cnxml'))
+        html = self.call_target(cnxml).getroot()
+
+        try:
+            elm = html.xpath("//*[@id='statement-test-section']")[0]
+        except IndexError:
+            transformed_html = etree.tostring(html)
+            self.fail("Failed to transform: \n" + transformed_html)
+        title_elm, note_elm = elm.getchildren()
+        self.assertEqual(title_elm.tag, 'h2')
+        self.assertEqual(title_elm.attrib['class'], 'title')
+
+    def test_proof_w_title(self):
+        """Verify conversion of //c:proof[c:title] to a section."""
+        cnxml = etree.parse(os.path.join(TEST_DATA_DIR, 'titles.cnxml'))
+        html = self.call_target(cnxml).getroot()
+
+        try:
+            elm = html.xpath("//*[@id='proof-test-section']")[0]
+        except IndexError:
+            transformed_html = etree.tostring(html)
+            self.fail("Failed to transform: \n" + transformed_html)
+        title_elm, note_elm = elm.getchildren()
+        self.assertEqual(title_elm.tag, 'h2')
+        self.assertEqual(title_elm.attrib['class'], 'title')
+
+    @unittest.skip("No instances of //c:commentary[c:title] exist in cnx.org.")
+    def test_commentary_w_title(self):
+        pass
+
+    @unittest.skip("No instances of //c:meaning[c:title] exist in cnx.org.")
+    def test_meaning_w_title(self):
+        pass

--- a/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
+++ b/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
@@ -237,6 +237,40 @@
   <div><xsl:apply-templates mode="class" select="."/><xsl:apply-templates select="@*|node()"/></div>
 </xsl:template>
 
+<xsl:template match="
+   c:example[c:title]
+  |c:exercise[c:title]
+  |c:problem[c:title]
+  |c:solution[c:title]
+  |c:equation[c:title]
+  |c:rule[c:title]
+  |c:statement[c:title]
+  |c:proof[c:title]">
+  <xsl:param name="depth" select="1"/>
+  <section>
+    <xsl:attribute name="data-depth"><xsl:value-of select="$depth"/></xsl:attribute>
+    <!-- Assign the section an id based on the selected node's id. -->
+    <xsl:if test="@id">
+      <xsl:attribute name="id">
+        <xsl:value-of select="concat(current()/@id, '-section')"/>
+      </xsl:attribute>
+    </xsl:if>
+    <xsl:apply-templates select="c:label"/>
+
+    <xsl:element name="h{$depth}">
+      <xsl:apply-templates mode="class" select="c:title"/>
+      <xsl:apply-templates select="c:title/@*|c:title/node()"/>
+    </xsl:element>
+
+    <div>
+      <xsl:apply-templates mode="class" select="."/>
+      <xsl:apply-templates select="@*|node()[not(self::c:title or self::c:label)]">
+        <xsl:with-param name="depth" select="$depth + 1"/>
+      </xsl:apply-templates>
+    </div>
+  </section>
+</xsl:template>
+
 <!-- ========================= -->
 <!-- Code alternatives -->
 <!-- ========================= -->
@@ -259,7 +293,7 @@
 
 <xsl:template match="
    c:code[c:title]
-  |c:preformat[c:title and not(display='inline')]">
+  |c:preformat[c:title and not(@display='inline')]">
   <xsl:param name="depth" select="1"/>
   <section>
     <xsl:attribute name="data-depth"><xsl:value-of select="$depth"/></xsl:attribute>
@@ -302,6 +336,33 @@
     <xsl:apply-templates mode="class" select="."/>
     <xsl:apply-templates select="@*|node()"/>
   </blockquote>
+</xsl:template>
+
+
+<xsl:template match="c:quote[c:title and not(@display='inline')]">
+  <xsl:param name="depth" select="1"/>
+  <section>
+    <xsl:attribute name="data-depth"><xsl:value-of select="$depth"/></xsl:attribute>
+    <!-- Assign the section an id based on the selected node's id. -->
+    <xsl:if test="@id">
+      <xsl:attribute name="id">
+        <xsl:value-of select="concat(current()/@id, '-section')"/>
+      </xsl:attribute>
+    </xsl:if>
+    <xsl:apply-templates select="c:label"/>
+
+    <xsl:element name="h{$depth}">
+      <xsl:apply-templates mode="class" select="c:title"/>
+      <xsl:apply-templates select="c:title/@*|c:title/node()"/>
+    </xsl:element>
+
+    <blockquote>
+      <xsl:apply-templates mode="class" select="."/>
+      <xsl:apply-templates select="@*|node()[not(self::c:title or self::c:label)]">
+        <xsl:with-param name="depth" select="$depth + 1"/>
+      </xsl:apply-templates>
+    </blockquote>
+  </section>
 </xsl:template>
 
 <!-- ========================= -->
@@ -537,6 +598,7 @@
   <span><xsl:apply-templates mode="class" select="."/><xsl:apply-templates select="@*|node()"/></span>
 </xsl:template>
 
+<!-- TODO: //c:footnote[c:title] -->
 <xsl:template match="c:footnote">
   <div><xsl:apply-templates mode="class" select="."/><xsl:apply-templates select="@*|node()"/></div>
 </xsl:template>
@@ -643,6 +705,33 @@
     <xsl:apply-templates select="c:caption"/>
     <xsl:apply-templates select="node()[not(self::c:title or self::c:caption or self::c:label)]"/>
   </figure>
+</xsl:template>
+
+<xsl:template match="c:figure|c:subfigure">
+  <xsl:param name="depth" select="1"/>
+  <section>
+    <xsl:attribute name="data-depth"><xsl:value-of select="$depth"/></xsl:attribute>
+    <!-- Assign the section an id based on the selected node's id. -->
+    <xsl:if test="@id">
+      <xsl:attribute name="id">
+        <xsl:value-of select="concat(current()/@id, '-section')"/>
+      </xsl:attribute>
+    </xsl:if>
+    <xsl:apply-templates select="c:label"/>
+
+    <xsl:element name="h{$depth}">
+      <xsl:apply-templates mode="class" select="c:title"/>
+      <xsl:apply-templates select="c:title/@*|c:title/node()"/>
+    </xsl:element>
+
+    <figure>
+      <xsl:apply-templates mode="class" select="."/>
+      <xsl:apply-templates select="c:caption"/>
+      <xsl:apply-templates select="node()[not(self::c:title or self::c:caption or self::c:label)]">
+        <xsl:with-param name="depth" select="$depth + 1"/>
+      </xsl:apply-templates>
+    </figure>
+  </section>
 </xsl:template>
 
 <!-- ========================= -->


### PR DESCRIPTION
This transforms found instance of section, preformat, para, quote, footnote, equation, note, list, code, figure, subfigure, example, exercise, problem, solution, commentary, meaning, rule, statement, proof and table elements with title elements to sections.
