### PR TITLE
Add a footnote section with extracted footnote text

### DIFF
--- a/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
+++ b/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
@@ -33,6 +33,14 @@
     <xsl:apply-templates select="c:title"/>
     <xsl:apply-templates select="c:metadata/md:abstract"/>
     <xsl:apply-templates select="c:content"/>
+    <xsl:if test="c:content//c:footnote">
+      <div data-type="footnote-refs">
+        <h2>Footnotes</h2>
+        <ol>
+          <xsl:apply-templates select="//c:footnote" mode="footnote"/>
+        </ol>
+      </div>
+    </xsl:if>
     <xsl:apply-templates select="c:glossary"/>
   </body>
 </xsl:template>
@@ -605,7 +613,30 @@
 </xsl:template>
 
 <xsl:template match="c:footnote">
-  <div data-type="{local-name()}"><xsl:apply-templates select="@*|node()"/></div>
+  <a data-type="{local-name()}-number">
+    <xsl:attribute name="name">
+      <xsl:text>footnote-ref</xsl:text><xsl:number level="any" count="c:footnote" format="1"/>
+    </xsl:attribute>
+    <xsl:attribute name="href">
+      <xsl:text>#footnote</xsl:text><xsl:number level="any" count="c:footnote" format="1"/>
+    </xsl:attribute>
+    <sup><xsl:number level="any" count="c:footnote" format="1"/></sup>
+  </a>
+</xsl:template>
+
+<xsl:template match="c:footnote" mode="footnote">
+    <li>
+      <a data-type="{local-name()}-ref">
+        <xsl:attribute name="name">
+          <xsl:text>footnote</xsl:text><xsl:number level="any" count="c:footnote" format="1"/>
+        </xsl:attribute>
+        <xsl:attribute name="href">
+          <xsl:text>#footnote-ref</xsl:text><xsl:number level="any" count="c:footnote" format="1"/>
+        </xsl:attribute>
+        <xsl:number level="any" count="c:footnote" format="1"/>
+      </a>
+      <xsl:text> </xsl:text><xsl:apply-templates/>
+    </li>
 </xsl:template>
 
 <xsl:template match="c:sub">

--- a/rhaptos/cnxmlutils/xsl/test/footnote.cnxml
+++ b/rhaptos/cnxmlutils/xsl/test/footnote.cnxml
@@ -1,0 +1,24 @@
+<document xmlns="http://cnx.rice.edu/cnxml" xmlns:md="http://cnx.rice.edu/mdml" xmlns:m="http://www.w3.org/1998/Math/MathML" xmlns:fo="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0" id="imported-from-openoffice" module-id="imported-from-openoffice" cnxml-version="0.7">
+  <title>Footnote test</title>
+<metadata xmlns:md="http://cnx.rice.edu/mdml" mdml-version="0.5">
+</metadata>
+
+<content>
+
+  <para> ... </para>
+
+  <para>(observed<footnote id="eip-id1169737806114">Predicted by theory and first observed in 1983.</footnote>)</para>
+
+  <para>Gluons (conjectured<footnote id="eip-id1169738239687">Eight proposed&#8212;indirect evidence of existence. Underlie meson exchange.</footnote>)</para>
+
+  <para> ... </para>       
+
+</content>
+<!-- Ensure the glossary appears after the footnotes. -->
+<!-- Note, there aren't any //c:glossary//c:footnote entries in production. -->
+<glossary>
+  <definition id="import-auto-id1169737716876"><term>Feynman diagram</term> <meaning id="fs-id1169738208078">a graph of time versus position that describes the exchange of virtual particles between subatomic particles</meaning></definition>
+  <definition id="import-auto-id1169737813579"><term>gluons</term> <meaning id="fs-id1169738116395">exchange particles, analogous to the exchange of photons that gives rise to the electromagnetic force between two charged particles</meaning></definition>
+  <definition id="import-auto-id1169738065015"><term>quantum electrodynamics</term> <meaning id="fs-id1169737896970">the theory of electromagnetism on the particle scale</meaning></definition>
+</glossary> 
+</document>

--- a/rhaptos/cnxmlutils/xsl/test/footnote.html
+++ b/rhaptos/cnxmlutils/xsl/test/footnote.html
@@ -1,0 +1,15 @@
+<body xmlns:c="http://cnx.rice.edu/cnxml" xmlns:md="http://cnx.rice.edu/mdml" xmlns:qml="http://cnx.rice.edu/qml/1.0" xmlns:mod="http://cnx.rice.edu/#moduleIds" xmlns:bib="http://bibtexml.sf.net/" xmlns:data="http://dev.w3.org/html5/spec/#custom"><div data-type="document-title">Footnote test</div>
+
+  <p> ... </p>
+
+  <p>(observed<a data-type="footnote-number" name="footnote-ref1" href="#footnote1"><sup>1</sup></a>)</p>
+
+  <p>Gluons (conjectured<a data-type="footnote-number" name="footnote-ref2" href="#footnote2"><sup>2</sup></a>)</p>
+
+  <p> ... </p>       
+
+<div data-type="footnote-refs"><h2>Footnotes</h2><ol><li><a data-type="footnote-ref" name="footnote1" href="#footnote-ref1">1</a> Predicted by theory and first observed in 1983.</li><li><a data-type="footnote-ref" name="footnote2" href="#footnote-ref2">2</a> Eight proposed&#8212;indirect evidence of existence. Underlie meson exchange.</li></ol></div><div data-type="glossary"><h2>Glossary</h2>
+  <div data-type="definition" id="import-auto-id1169737716876"><span data-type="term">Feynman diagram</span> <div data-type="meaning" id="fs-id1169738208078">a graph of time versus position that describes the exchange of virtual particles between subatomic particles</div></div>
+  <div data-type="definition" id="import-auto-id1169737813579"><span data-type="term">gluons</span> <div data-type="meaning" id="fs-id1169738116395">exchange particles, analogous to the exchange of photons that gives rise to the electromagnetic force between two charged particles</div></div>
+  <div data-type="definition" id="import-auto-id1169738065015"><span data-type="term">quantum electrodynamics</span> <div data-type="meaning" id="fs-id1169737896970">the theory of electromagnetism on the particle scale</div></div>
+</div></body>


### PR DESCRIPTION
This provides a section of footnotes at the bottom of a transformed page. The footnotes like to and from the reference using footnote numbering.
