### PR TITLE
Remove setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,0 @@
-[egg_info]
-tag_build = dev
-tag_svn_revision = true


### PR DESCRIPTION
setup.cfg prevents me from installing rhaptos.cnxmlutils correctly on my
system.  Running `python setup.py install` appears to work but the code
in /usr/local/lib/python2.7 is not updated.
