### PR TITLE
Transform lists in paras into inline lists and block lists

### DIFF
--- a/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
+++ b/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
@@ -176,13 +176,13 @@
   </div>
 </xsl:template>
 
-<xsl:template match="c:title">
+<xsl:template match="c:title|c:para//c:list[not(@display)]/c:title|c:para//c:list[@display='block']/c:title">
   <div data-type="title">
     <xsl:apply-templates select="@*|node()"/>
   </div>
 </xsl:template>
 
-<xsl:template match="c:para/c:title|c:table/c:title|c:para//c:title">
+<xsl:template match="c:para/c:title|c:table/c:title|c:para//c:title[not(parent::c:list)]|c:para//c:list[@display='inline']/c:title">
   <span data-type="title"><xsl:apply-templates select="@*|node()"/></span>
 </xsl:template>
 
@@ -381,7 +381,7 @@
   </div>
 </xsl:template>
 
-<xsl:template match="c:para//c:list[c:title]">
+<xsl:template match="c:para//c:list[c:title][@display='inline']">
   <span data-type="{local-name()}"><!-- list-id-and-class will give it the class "list" at least -->
     <xsl:call-template name="list-id-and-class"/>
     <xsl:apply-templates select="c:title"/>
@@ -445,7 +445,23 @@
 <!-- Inline-level lists -->
 <!-- ================= -->
 
-<xsl:template mode="list-mode" match="c:para//c:list|c:list[@display='inline']">
+<xsl:template mode="list-mode" match="c:para//c:list[not(@display)]|c:para//c:list[@display='block']">
+  <xsl:param name="convert-id-and-class"/>
+  <xsl:variable name="list-type">
+    <xsl:choose>
+      <xsl:when test="not(@list-type)">bulleted</xsl:when>
+      <xsl:otherwise><xsl:value-of select="@list-type"/></xsl:otherwise>
+    </xsl:choose>
+  </xsl:variable>
+  <div data-type="list" data-list-type="{$list-type}">
+    <xsl:if test="$convert-id-and-class">
+      <xsl:call-template name="list-id-and-class"/>
+    </xsl:if>
+    <xsl:apply-templates select="@*['id' != local-name()]|node()[not(self::c:title)]"/>
+  </div>
+</xsl:template>
+
+<xsl:template mode="list-mode" match="c:list[@display='inline']">
   <xsl:param name="convert-id-and-class"/>
   <xsl:variable name="list-type">
     <xsl:choose>
@@ -461,8 +477,12 @@
   </span>
 </xsl:template>
 
-<xsl:template match="c:para//c:list/c:item|c:list[@display='inline']/c:item">
+<xsl:template match="c:list[@display='inline']/c:item">
   <span data-type="item"><xsl:apply-templates select="@*|node()"/></span>
+</xsl:template>
+
+<xsl:template match="c:para//c:list[@display='block']/c:item|c:para//c:list[not(@display)]/c:item">
+  <div data-type="item"><xsl:apply-templates select="@*|node()"/></div>
 </xsl:template>
 
 

--- a/rhaptos/cnxmlutils/xsl/test/definition.html
+++ b/rhaptos/cnxmlutils/xsl/test/definition.html
@@ -2,13 +2,13 @@
     <section data-depth="1" id="cid1"><h1 data-type="title">Introduction</h1><p id="id62175">All the objects that we see in the world around us, are made of <strong data-effect="bold">matter</strong>. Matter makes up the air we breathe, the ground we walk on, the food we eat and the animals and plants that live around us. Even our own human bodies are made of matter!</p>
       <p id="id62185">Different objects can be made of different types of matter, or <strong data-effect="bold">materials</strong>. For example, a cupboard (an <em data-effect="italics">object</em>) is made of wood, nails and hinges (the <em data-effect="italics">materials</em>). The <strong data-effect="bold">properties</strong> of the materials will affect the properties of the object. In the example of the cupboard, the strength of the wood and metals make the cupboard strong and durable. In the same way, the raincoats that you wear during bad weather, are made of a material that is waterproof. The electrical wires in your home are made of metal because metals are a type of material that is able to conduct electricity. It is very important to understand the properties of materials, so that we can use them in our homes, in industry and in other applications. In this chapter, we will be looking at different types of materials and their properties.</p>
 <p id="id0132">Some of the properties of matter that you should know are:
-<span data-type="list" data-list-type="bulleted" id="lid825"><span data-type="item" data-label="Strength">Materials can be strong and resist bending (e.g. iron rods, cement) or weak (e.g. fabrics)</span>
-<span data-type="item" data-label="Thermal and electrical conductivity">Materials that conduct heat (e.g. metals) are called thermal conductors. Materials that conduct electricity are electrical conductors.</span>
-<span data-type="item" data-label="Brittle, malleable or ductile">Brittle materials break easily. Materials that are malleable can be easily formed into different shapes. Ductile materials are able to be formed into long wires.</span>
-<span data-type="item" data-label="Magnetic or non-magnetic">Magnetic materials have a magnetic field.</span>
-<span data-type="item" data-label="Density">Density is the mass per unit volume. An example of a dense material is concrete.</span>
-<span data-type="item" data-label="Boiling and melting points">The boiling and melting points of substance help us to classify substances as solids, liquids or gases at a specific temperature.</span>
-</span>
+<div data-type="list" data-list-type="bulleted" id="lid825"><div data-type="item" data-label="Strength">Materials can be strong and resist bending (e.g. iron rods, cement) or weak (e.g. fabrics)</div>
+<div data-type="item" data-label="Thermal and electrical conductivity">Materials that conduct heat (e.g. metals) are called thermal conductors. Materials that conduct electricity are electrical conductors.</div>
+<div data-type="item" data-label="Brittle, malleable or ductile">Brittle materials break easily. Materials that are malleable can be easily formed into different shapes. Ductile materials are able to be formed into long wires.</div>
+<div data-type="item" data-label="Magnetic or non-magnetic">Magnetic materials have a magnetic field.</div>
+<div data-type="item" data-label="Density">Density is the mass per unit volume. An example of a dense material is concrete.</div>
+<div data-type="item" data-label="Boiling and melting points">The boiling and melting points of substance help us to classify substances as solids, liquids or gases at a specific temperature.</div>
+</div>
 </p>
       <p id="id62556">The diagram below shows one way in which matter can be classified (grouped) according to its different properties. As you read further in this chapter, you will see that there are also other ways of classifying materials, for example according to whether or not they are good electrical conductors.</p>
       <figure id="uid1"><figcaption>The classification of matter</figcaption><span data-type="media" id="uid1_media" data-alt="">
@@ -52,12 +52,12 @@ To separate something by 'mechanical means', means that there is no chemical pro
      
 <div data-type="exercise" id="eip-479"><div data-type="title">Mixtures</div><div data-type="problem" id="eip-277">
   <p id="eip-353">For each of the following mixtures state whether it is a homogenous or a heterogenous mixture:
-<span data-type="list" data-list-type="enumerated" id="eip-id1167649056231" data-number-style="lower-alpha">
-<span data-type="item">sugar and water</span>
-<span data-type="item">flour and iron filings (small pieces of iron)</span>
-<span data-type="item">flour and baking powder</span>
-<span data-type="item">smarties, jelly tots and peppermints</span>
-</span>
+<div data-type="list" data-list-type="enumerated" id="eip-id1167649056231" data-number-style="lower-alpha">
+<div data-type="item">sugar and water</div>
+<div data-type="item">flour and iron filings (small pieces of iron)</div>
+<div data-type="item">flour and baking powder</div>
+<div data-type="item">smarties, jelly tots and peppermints</div>
+</div>
   </p>
 </div>
 
@@ -112,12 +112,12 @@ Place a smartie in the center of a piece of filter paper. Carefully drop a few d
 <p id="eip-595">One way to think of mixtures and compounds is to think of buildings. The building is a mixture of different building materials (e.g. glass, bricks, cement, etc.). The building materials are all compounds. You can also think of the elements as Lego blocks. Each Lego block can be added to other Lego blocks to make new structures, in the same way that elements can combine to make compounds. </p><div data-type="exercise" id="eip-524"><div data-type="title">Mixtures and pure substances</div><div data-type="problem" id="eip-259">
   <p id="eip-457">
 For each of the following substances state whether it is a pure substance or a mixture. If it is a mixture, is it homogenous or heterogenous? If it is a pure substance is it an element or a compound? 
-<span data-type="list" data-list-type="enumerated" id="eip-id1167351497334" data-number-style="lower-alpha">
-<span data-type="item">Blood</span>
-<span data-type="item">Argon</span>
-<span data-type="item">Silicon dioxide (<math xmlns="http://www.w3.org/1998/Math/MathML"><msub><mi>SiO</mi><mn>2</mn></msub></math>)</span>
-<span data-type="item">Sand and stones</span>
-</span>
+<div data-type="list" data-list-type="enumerated" id="eip-id1167351497334" data-number-style="lower-alpha">
+<div data-type="item">Blood</div>
+<div data-type="item">Argon</div>
+<div data-type="item">Silicon dioxide (<math xmlns="http://www.w3.org/1998/Math/MathML"><msub><mi>SiO</mi><mn>2</mn></msub></math>)</div>
+<div data-type="item">Sand and stones</div>
+</div>
   </p>
 </div>
 
@@ -130,15 +130,15 @@ For each of the following substances state whether it is a pure substance or a m
 </ol>
 </div>
 </div><p id="eip-326"><span data-type="title">Activity: Using models to represent substances</span>Use coloured balls and sticks to represent elements and compounds. Some examples that you can try to build are:
-<span data-type="list" data-list-type="bulleted" id="eip-id1166921187210"><span data-type="item">Hydrogen</span>
-<span data-type="item">Oxygen</span>
-<span data-type="item">Nitrogen</span>
-<span data-type="item">Neon</span>
-<span data-type="item">Sodium chloride (salt, <math xmlns="http://www.w3.org/1998/Math/MathML"><mi>NaCl</mi></math>)</span>
-<span data-type="item">Potassium permanganate (<math xmlns="http://www.w3.org/1998/Math/MathML"><msub><mi mathvariant="normal">KMnO</mi><mn>4</mn></msub></math>)</span>
-<span data-type="item">Water (<math xmlns="http://www.w3.org/1998/Math/MathML"><msub><mi mathvariant="normal">H</mi><mn>2</mn></msub><mi mathvariant="normal">O</mi></math>)</span>
-<span data-type="item">Iron sulphide (<math xmlns="http://www.w3.org/1998/Math/MathML"><mi>FeS</mi></math>)</span>
-</span>
+<div data-type="list" data-list-type="bulleted" id="eip-id1166921187210"><div data-type="item">Hydrogen</div>
+<div data-type="item">Oxygen</div>
+<div data-type="item">Nitrogen</div>
+<div data-type="item">Neon</div>
+<div data-type="item">Sodium chloride (salt, <math xmlns="http://www.w3.org/1998/Math/MathML"><mi>NaCl</mi></math>)</div>
+<div data-type="item">Potassium permanganate (<math xmlns="http://www.w3.org/1998/Math/MathML"><msub><mi mathvariant="normal">KMnO</mi><mn>4</mn></msub></math>)</div>
+<div data-type="item">Water (<math xmlns="http://www.w3.org/1998/Math/MathML"><msub><mi mathvariant="normal">H</mi><mn>2</mn></msub><mi mathvariant="normal">O</mi></math>)</div>
+<div data-type="item">Iron sulphide (<math xmlns="http://www.w3.org/1998/Math/MathML"><mi>FeS</mi></math>)</div>
+</div>
 Think about the way that we represent substances microscopically. Would you use just one ball to represent an element or many? Why? </p><section data-depth="3" id="secfhsst_id212"><h3 data-type="title">Elements, mixtures and compounds         </h3><ol id="id63472" data-display="block">
           <li id="uid28">In the following table, tick whether each of the substances listed is a <em data-effect="italics">mixture</em> or a <em data-effect="italics">pure substance</em>. If it is a mixture, also say whether it is a homogeneous or heterogeneous mixture.
 
@@ -193,9 +193,9 @@ Think about the way that we represent substances microscopically. Would you use 
 </div>
 <p id="eip-163">We can use these rules to help us name both ionic compounds and covalent compounds (more on these compounds will be covered in a later chapter). However, covalent compounds are often given other names by scientists to simplify the name (or because the molecule was named long before its formula was discovered). For example, if we have 2 hydrogen atoms and one oxygen atom the above naming rules would tell us that the substance is dihydrogen monoxide. But this compound is better known as water! Or if we had 1 carbon atom and 4 hydrogen atoms then the name would be carbon tetrahydride, but scientists call this compound methane.  </p><div data-type="exercise" id="eip-254"><div data-type="title">Naming compounds</div><div data-type="problem" id="eip-671">
   <p id="eip-870">
-    What is the chemical name for <span data-type="list" data-list-type="enumerated" id="id734" data-number-style="lower-alpha"><span data-type="item"> 
- <math xmlns="http://www.w3.org/1998/Math/MathML"><mi mathvariant="normal">K</mi><msub><mi>MnO</mi><mn>4</mn></msub></math></span>
-<span data-type="item"><math xmlns="http://www.w3.org/1998/Math/MathML"><msub><mi>NH</mi><mn>4</mn></msub><mi>Cl</mi></math></span></span>
+    What is the chemical name for <div data-type="list" data-list-type="enumerated" id="id734" data-number-style="lower-alpha"><div data-type="item"> 
+ <math xmlns="http://www.w3.org/1998/Math/MathML"><mi mathvariant="normal">K</mi><msub><mi>MnO</mi><mn>4</mn></msub></math></div>
+<div data-type="item"><math xmlns="http://www.w3.org/1998/Math/MathML"><msub><mi>NH</mi><mn>4</mn></msub><mi>Cl</mi></math></div></div>
   </p>
 </div>
 
@@ -208,10 +208,10 @@ Think about the way that we represent substances microscopically. Would you use 
 </div>
 </div><div data-type="exercise" id="eip-530"><div data-type="problem" id="eip-196">
   <p id="eip-535">Write the chemical formulae for: 
-<span data-type="list" data-list-type="enumerated" id="id87432" data-number-style="lower-alpha">
-<span data-type="item">sodium sulphate</span>
-<span data-type="item">potassium chromate</span>
-</span>
+<div data-type="list" data-list-type="enumerated" id="id87432" data-number-style="lower-alpha">
+<div data-type="item">sodium sulphate</div>
+<div data-type="item">potassium chromate</div>
+</div>
   </p>
 </div>
 
@@ -314,12 +314,12 @@ Metals usually have a high melting point and can therefore be used to make cooki
       </section><p id="eip-690">You should now be able to take any material and determine whether it is a metal, non-metal or metalloid simply by using its properties. </p><div data-type="exercise" id="eip-586"><div data-type="title">Metals, metalloids and non-metals 1</div><div data-type="problem" id="eip-77">
   <p id="eip-252">
 For each of the following substances state whether they are metals, metalloids or non-metals, using their position on the periodic table.
-<span data-type="list" data-list-type="enumerated" id="eip-id1170734629720" data-number-style="lower-alpha">
-<span data-type="item">Oxygen</span>
-<span data-type="item">Arsenic</span>
-<span data-type="item">Vanadium</span>
-<span data-type="item">Potassium</span>
-</span>
+<div data-type="list" data-list-type="enumerated" id="eip-id1170734629720" data-number-style="lower-alpha">
+<div data-type="item">Oxygen</div>
+<div data-type="item">Arsenic</div>
+<div data-type="item">Vanadium</div>
+<div data-type="item">Potassium</div>
+</div>
   </p>
 </div>
 
@@ -333,11 +333,11 @@ For each of the following substances state whether they are metals, metalloids o
 </div>
 </div><div data-type="exercise" id="eip-173"><div data-type="title">Metals, metalloids and non-metals 2</div><div data-type="problem" id="eip-757">
   <p id="eip-25442">For each of the following substances state whether they are metals, metalloids or non-metals, using the information given.
-<span data-type="list" data-list-type="enumerated" id="eip-id1170742635239" data-number-style="lower-alpha"><span data-type="item">Aluminium in a cooking pot</span>
-<span data-type="item">Silicon in a computer chip</span>
-<span data-type="item">Plastic insulation around a wire</span>
-<span data-type="item">Silver jewellery</span>
-</span>
+<div data-type="list" data-list-type="enumerated" id="eip-id1170742635239" data-number-style="lower-alpha"><div data-type="item">Aluminium in a cooking pot</div>
+<div data-type="item">Silicon in a computer chip</div>
+<div data-type="item">Plastic insulation around a wire</div>
+<div data-type="item">Silver jewellery</div>
+</div>
   </p>
 </div>
 

--- a/rhaptos/cnxmlutils/xsl/test/list.cnxml
+++ b/rhaptos/cnxmlutils/xsl/test/list.cnxml
@@ -118,9 +118,18 @@
     <item>list with item</item>
   </list>...</para>
 
+  <para>...<list display="inline">
+    <item>list with item (inline)</item>
+  </list>...</para>
+
   <para>...<list>
     <title>and title</title>
     <item>and item</item>
+  </list>...</para>
+
+  <para>...<list display="inline">
+    <title>and title</title>
+    <item>and item (inline)</item>
   </list>...</para>
 
   <section><title>Default list:</title>
@@ -131,20 +140,38 @@
       <item>and item</item>
     </list>...</para>
 
+    <para>...<list id="id1-inline" display="inline">
+      <item>and item (inline)</item>
+    </list>...</para>
+
     <para>...<list id="id2">
       <title>and title</title>
       <item>and item</item>
     </list>...</para>
 
+    <para>...<list id="id2-inline" display="inline">
+      <title>and title</title>
+      <item>and item (inline)</item>
+    </list>...</para>
+
     <para>... with all attributes</para>
 
-    <para>...<list id="id3" bullet-style="open-circle" number-style="lower-alpha" start-value="3" mark-prefix="[PREFIX]" mark-suffix="[SUFFIX]" item-sep="[SEPARATOR]" display="IGNORE-ME" type="LIST-TYPE">
+    <para>...<list id="id3" bullet-style="open-circle" number-style="lower-alpha" start-value="3" mark-prefix="[PREFIX]" mark-suffix="[SUFFIX]" item-sep="[SEPARATOR]" type="LIST-TYPE">
       <item>list with all attributes</item>
     </list>...</para>
 
-    <para>...<list id="id3" bullet-style="open-circle" number-style="lower-alpha" start-value="3" mark-prefix="[PREFIX]" mark-suffix="[SUFFIX]" item-sep="[SEPARATOR]" display="IGNORE-ME" type="LIST-TYPE">
+    <para>...<list id="id3-inline" bullet-style="open-circle" number-style="lower-alpha" start-value="3" mark-prefix="[PREFIX]" mark-suffix="[SUFFIX]" item-sep="[SEPARATOR]" display="inline" type="LIST-TYPE">
+      <item>list with all attributes (inline)</item>
+    </list>...</para>
+
+    <para>...<list id="id4" bullet-style="open-circle" number-style="lower-alpha" start-value="3" mark-prefix="[PREFIX]" mark-suffix="[SUFFIX]" item-sep="[SEPARATOR]" display="block" type="LIST-TYPE">
       <title>list with all attributes and title</title>
       <item>and item</item>
+    </list>...</para>
+
+    <para>...<list id="id4-inline" bullet-style="open-circle" number-style="lower-alpha" start-value="3" mark-prefix="[PREFIX]" mark-suffix="[SUFFIX]" item-sep="[SEPARATOR]" display="inline" type="LIST-TYPE">
+      <title>list with all attributes and title</title>
+      <item>and item (inline)</item>
     </list>...</para>
 
   </section>
@@ -159,20 +186,38 @@
       <item>and item</item>
     </list>...</para>
 
+    <para>...<list list-type="bulleted" id="id1-inline" display="inline">
+      <item>and item (inline)</item>
+    </list>...</para>
+
     <para>...<list list-type="bulleted" id="id2">
       <title>and title</title>
       <item>and item</item>
     </list>...</para>
 
+    <para>...<list list-type="bulleted" id="id2-inline" display="inline">
+      <title>and title</title>
+      <item>and item (inline)</item>
+    </list>...</para>
+
     <para>... with all attributes</para>
 
-    <para>...<list list-type="bulleted" id="id3" bullet-style="open-circle" number-style="lower-alpha" start-value="3" mark-prefix="[PREFIX]" mark-suffix="[SUFFIX]" item-sep="[SEPARATOR]" display="IGNORE-ME" type="LIST-TYPE">
+    <para>...<list list-type="bulleted" id="id3" bullet-style="open-circle" number-style="lower-alpha" start-value="3" mark-prefix="[PREFIX]" mark-suffix="[SUFFIX]" item-sep="[SEPARATOR]" type="LIST-TYPE">
       <item>list with all attributes</item>
     </list>...</para>
 
-    <para>...<list list-type="bulleted" id="id3" bullet-style="open-circle" number-style="lower-alpha" start-value="3" mark-prefix="[PREFIX]" mark-suffix="[SUFFIX]" item-sep="[SEPARATOR]" display="IGNORE-ME" type="LIST-TYPE">
+    <para>...<list list-type="bulleted" id="id3-inline" bullet-style="open-circle" number-style="lower-alpha" start-value="3" mark-prefix="[PREFIX]" mark-suffix="[SUFFIX]" item-sep="[SEPARATOR]" display="inline" type="LIST-TYPE">
+      <item>list with all attributes (inline)</item>
+    </list>...</para>
+
+    <para>...<list list-type="bulleted" id="id4" bullet-style="open-circle" number-style="lower-alpha" start-value="3" mark-prefix="[PREFIX]" mark-suffix="[SUFFIX]" item-sep="[SEPARATOR]" display="block" type="LIST-TYPE">
       <title>list with all attributes and title</title>
       <item>and item</item>
+    </list>...</para>
+
+    <para>...<list list-type="bulleted" id="id4-inline" bullet-style="open-circle" number-style="lower-alpha" start-value="3" mark-prefix="[PREFIX]" mark-suffix="[SUFFIX]" item-sep="[SEPARATOR]" display="inline" type="LIST-TYPE">
+      <title>list with all attributes and title</title>
+      <item>and item (inline)</item>
     </list>...</para>
 
   </section>
@@ -186,20 +231,38 @@
       <item>and item</item>
     </list>...</para>
 
+    <para>...<list list-type="enumerated" id="id1-inline" display="inline">
+      <item>and item (inline)</item>
+    </list>...</para>
+
     <para>...<list list-type="enumerated" id="id2">
       <title>and title</title>
       <item>and item</item>
     </list>...</para>
 
+    <para>...<list list-type="enumerated" id="id2-inline" display="inline">
+      <title>and title</title>
+      <item>and item (inline)</item>
+    </list>...</para>
+
     <para>... with all attributes</para>
 
-    <para>...<list list-type="enumerated" id="id3" bullet-style="open-circle" number-style="lower-alpha" start-value="3" mark-prefix="[PREFIX]" mark-suffix="[SUFFIX]" item-sep="[SEPARATOR]" display="IGNORE-ME" type="LIST-TYPE">
+    <para>...<list list-type="enumerated" id="id3" bullet-style="open-circle" number-style="lower-alpha" start-value="3" mark-prefix="[PREFIX]" mark-suffix="[SUFFIX]" item-sep="[SEPARATOR]" display="block" type="LIST-TYPE">
       <item>list with all attributes</item>
     </list>...</para>
 
-    <para>...<list list-type="enumerated" id="id3" bullet-style="open-circle" number-style="lower-alpha" start-value="3" mark-prefix="[PREFIX]" mark-suffix="[SUFFIX]" item-sep="[SEPARATOR]" display="IGNORE-ME" type="LIST-TYPE">
+    <para>...<list list-type="enumerated" id="id3-inline" bullet-style="open-circle" number-style="lower-alpha" start-value="3" mark-prefix="[PREFIX]" mark-suffix="[SUFFIX]" item-sep="[SEPARATOR]" display="inline" type="LIST-TYPE">
+      <item>list with all attributes (inline)</item>
+    </list>...</para>
+
+    <para>...<list list-type="enumerated" id="id4" bullet-style="open-circle" number-style="lower-alpha" start-value="3" mark-prefix="[PREFIX]" mark-suffix="[SUFFIX]" item-sep="[SEPARATOR]" display="block" type="LIST-TYPE">
       <title>list with all attributes and title</title>
       <item>and item</item>
+    </list>...</para>
+
+    <para>...<list list-type="enumerated" id="id4-inline" bullet-style="open-circle" number-style="lower-alpha" start-value="3" mark-prefix="[PREFIX]" mark-suffix="[SUFFIX]" item-sep="[SEPARATOR]" display="inline" type="LIST-TYPE">
+      <title>list with all attributes and title</title>
+      <item>and item (inline)</item>
     </list>...</para>
 
   </section>
@@ -209,6 +272,10 @@
 
     <para>...<list list-type="labeled-item" id="id1">
       <item><label>with a label</label> and item</item>
+    </list>...</para>
+
+    <para>...<list list-type="labeled-item" id="id1-inline" display="inline">
+      <item><label>with a label</label> and item (inline)</item>
     </list>...</para>
 
   </section>

--- a/rhaptos/cnxmlutils/xsl/test/list.html
+++ b/rhaptos/cnxmlutils/xsl/test/list.html
@@ -102,34 +102,58 @@
 
   <section data-depth="1"><h1 data-type="title">The same tests but inside a paragraph (lists with titles should become spans instead of divs</h1>
 
-  <p>...<span data-type="list" data-list-type="bulleted">
-    <span data-type="item">list with item</span>
+  <p>...<div data-type="list" data-list-type="bulleted">
+    <div data-type="item">list with item</div>
+  </div>...</p>
+
+  <p>...<span data-type="list" data-list-type="bulleted" data-display="inline">
+    <span data-type="item">list with item (inline)</span>
   </span>...</p>
 
-  <p>...<span data-type="list"><span data-type="title">and title</span><span data-type="list" data-list-type="bulleted">
-    <span data-type="item">and item</span>
+  <p>...<div data-type="list"><div data-type="title">and title</div><div data-type="list" data-list-type="bulleted">
+    <div data-type="item">and item</div>
+  </div></div>...</p>
+
+  <p>...<span data-type="list"><span data-type="title">and title</span><span data-type="list" data-list-type="bulleted" data-display="inline">
+    <span data-type="item">and item (inline)</span>
   </span></span>...</p>
 
   <section data-depth="2"><h2 data-type="title">Default list:</h2>
 
     <p>with just an id attribute</p>
 
-    <p>...<span data-type="list" data-list-type="bulleted" id="id1">
-      <span data-type="item">and item</span>
+    <p>...<div data-type="list" data-list-type="bulleted" id="id1">
+      <div data-type="item">and item</div>
+    </div>...</p>
+
+    <p>...<span data-type="list" data-list-type="bulleted" id="id1-inline" data-display="inline">
+      <span data-type="item">and item (inline)</span>
     </span>...</p>
 
-    <p>...<span data-type="list" id="id2"><span data-type="title">and title</span><span data-type="list" data-list-type="bulleted">
-      <span data-type="item">and item</span>
+    <p>...<div data-type="list" id="id2"><div data-type="title">and title</div><div data-type="list" data-list-type="bulleted">
+      <div data-type="item">and item</div>
+    </div></div>...</p>
+
+    <p>...<span data-type="list" id="id2-inline"><span data-type="title">and title</span><span data-type="list" data-list-type="bulleted" data-display="inline">
+      <span data-type="item">and item (inline)</span>
     </span></span>...</p>
 
     <p>... with all attributes</p>
 
-    <p>...<span data-type="LIST-TYPE" data-list-type="bulleted" id="id3" data-bullet-style="open-circle" data-number-style="lower-alpha" start="3" data-mark-prefix="[PREFIX]" data-mark-suffix="[SUFFIX]" data-item-sep="[SEPARATOR]" data-display="IGNORE-ME">
-      <span data-type="item">list with all attributes</span>
+    <p>...<div data-type="LIST-TYPE" data-list-type="bulleted" id="id3" data-bullet-style="open-circle" data-number-style="lower-alpha" start="3" data-mark-prefix="[PREFIX]" data-mark-suffix="[SUFFIX]" data-item-sep="[SEPARATOR]">
+      <div data-type="item">list with all attributes</div>
+    </div>...</p>
+
+    <p>...<span data-type="LIST-TYPE" data-list-type="bulleted" id="id3-inline" data-bullet-style="open-circle" data-number-style="lower-alpha" start="3" data-mark-prefix="[PREFIX]" data-mark-suffix="[SUFFIX]" data-item-sep="[SEPARATOR]" data-display="inline">
+      <span data-type="item">list with all attributes (inline)</span>
     </span>...</p>
 
-    <p>...<span data-type="list" id="id3"><span data-type="title">list with all attributes and title</span><span data-type="LIST-TYPE" data-list-type="bulleted" data-bullet-style="open-circle" data-number-style="lower-alpha" start="3" data-mark-prefix="[PREFIX]" data-mark-suffix="[SUFFIX]" data-item-sep="[SEPARATOR]" data-display="IGNORE-ME">
-      <span data-type="item">and item</span>
+    <p>...<div data-type="list" id="id4"><div data-type="title">list with all attributes and title</div><div data-type="LIST-TYPE" data-list-type="bulleted" data-bullet-style="open-circle" data-number-style="lower-alpha" start="3" data-mark-prefix="[PREFIX]" data-mark-suffix="[SUFFIX]" data-item-sep="[SEPARATOR]" data-display="block">
+      <div data-type="item">and item</div>
+    </div></div>...</p>
+
+    <p>...<span data-type="list" id="id4-inline"><span data-type="title">list with all attributes and title</span><span data-type="LIST-TYPE" data-list-type="bulleted" data-bullet-style="open-circle" data-number-style="lower-alpha" start="3" data-mark-prefix="[PREFIX]" data-mark-suffix="[SUFFIX]" data-item-sep="[SEPARATOR]" data-display="inline">
+      <span data-type="item">and item (inline)</span>
     </span></span>...</p>
 
   </section>
@@ -140,22 +164,38 @@
 
     <p>with just an id attribute</p>
 
-    <p>...<span data-type="list" data-list-type="bulleted" id="id1">
-      <span data-type="item">and item</span>
+    <p>...<div data-type="list" data-list-type="bulleted" id="id1">
+      <div data-type="item">and item</div>
+    </div>...</p>
+
+    <p>...<span data-type="list" data-list-type="bulleted" id="id1-inline" data-display="inline">
+      <span data-type="item">and item (inline)</span>
     </span>...</p>
 
-    <p>...<span data-type="list" id="id2"><span data-type="title">and title</span><span data-type="list" data-list-type="bulleted">
-      <span data-type="item">and item</span>
+    <p>...<div data-type="list" id="id2"><div data-type="title">and title</div><div data-type="list" data-list-type="bulleted">
+      <div data-type="item">and item</div>
+    </div></div>...</p>
+
+    <p>...<span data-type="list" id="id2-inline"><span data-type="title">and title</span><span data-type="list" data-list-type="bulleted" data-display="inline">
+      <span data-type="item">and item (inline)</span>
     </span></span>...</p>
 
     <p>... with all attributes</p>
 
-    <p>...<span data-type="LIST-TYPE" data-list-type="bulleted" id="id3" data-bullet-style="open-circle" data-number-style="lower-alpha" start="3" data-mark-prefix="[PREFIX]" data-mark-suffix="[SUFFIX]" data-item-sep="[SEPARATOR]" data-display="IGNORE-ME">
-      <span data-type="item">list with all attributes</span>
+    <p>...<div data-type="LIST-TYPE" data-list-type="bulleted" id="id3" data-bullet-style="open-circle" data-number-style="lower-alpha" start="3" data-mark-prefix="[PREFIX]" data-mark-suffix="[SUFFIX]" data-item-sep="[SEPARATOR]">
+      <div data-type="item">list with all attributes</div>
+    </div>...</p>
+
+    <p>...<span data-type="LIST-TYPE" data-list-type="bulleted" id="id3-inline" data-bullet-style="open-circle" data-number-style="lower-alpha" start="3" data-mark-prefix="[PREFIX]" data-mark-suffix="[SUFFIX]" data-item-sep="[SEPARATOR]" data-display="inline">
+      <span data-type="item">list with all attributes (inline)</span>
     </span>...</p>
 
-    <p>...<span data-type="list" id="id3"><span data-type="title">list with all attributes and title</span><span data-type="LIST-TYPE" data-list-type="bulleted" data-bullet-style="open-circle" data-number-style="lower-alpha" start="3" data-mark-prefix="[PREFIX]" data-mark-suffix="[SUFFIX]" data-item-sep="[SEPARATOR]" data-display="IGNORE-ME">
-      <span data-type="item">and item</span>
+    <p>...<div data-type="list" id="id4"><div data-type="title">list with all attributes and title</div><div data-type="LIST-TYPE" data-list-type="bulleted" data-bullet-style="open-circle" data-number-style="lower-alpha" start="3" data-mark-prefix="[PREFIX]" data-mark-suffix="[SUFFIX]" data-item-sep="[SEPARATOR]" data-display="block">
+      <div data-type="item">and item</div>
+    </div></div>...</p>
+
+    <p>...<span data-type="list" id="id4-inline"><span data-type="title">list with all attributes and title</span><span data-type="LIST-TYPE" data-list-type="bulleted" data-bullet-style="open-circle" data-number-style="lower-alpha" start="3" data-mark-prefix="[PREFIX]" data-mark-suffix="[SUFFIX]" data-item-sep="[SEPARATOR]" data-display="inline">
+      <span data-type="item">and item (inline)</span>
     </span></span>...</p>
 
   </section>
@@ -165,22 +205,38 @@
 
     <p>with just an id attribute</p>
 
-    <p>...<span data-type="list" data-list-type="enumerated" id="id1">
-      <span data-type="item">and item</span>
+    <p>...<div data-type="list" data-list-type="enumerated" id="id1">
+      <div data-type="item">and item</div>
+    </div>...</p>
+
+    <p>...<span data-type="list" data-list-type="enumerated" id="id1-inline" data-display="inline">
+      <span data-type="item">and item (inline)</span>
     </span>...</p>
 
-    <p>...<span data-type="list" id="id2"><span data-type="title">and title</span><span data-type="list" data-list-type="enumerated">
-      <span data-type="item">and item</span>
+    <p>...<div data-type="list" id="id2"><div data-type="title">and title</div><div data-type="list" data-list-type="enumerated">
+      <div data-type="item">and item</div>
+    </div></div>...</p>
+
+    <p>...<span data-type="list" id="id2-inline"><span data-type="title">and title</span><span data-type="list" data-list-type="enumerated" data-display="inline">
+      <span data-type="item">and item (inline)</span>
     </span></span>...</p>
 
     <p>... with all attributes</p>
 
-    <p>...<span data-type="LIST-TYPE" data-list-type="enumerated" id="id3" data-bullet-style="open-circle" data-number-style="lower-alpha" start="3" data-mark-prefix="[PREFIX]" data-mark-suffix="[SUFFIX]" data-item-sep="[SEPARATOR]" data-display="IGNORE-ME">
-      <span data-type="item">list with all attributes</span>
+    <p>...<div data-type="LIST-TYPE" data-list-type="enumerated" id="id3" data-bullet-style="open-circle" data-number-style="lower-alpha" start="3" data-mark-prefix="[PREFIX]" data-mark-suffix="[SUFFIX]" data-item-sep="[SEPARATOR]" data-display="block">
+      <div data-type="item">list with all attributes</div>
+    </div>...</p>
+
+    <p>...<span data-type="LIST-TYPE" data-list-type="enumerated" id="id3-inline" data-bullet-style="open-circle" data-number-style="lower-alpha" start="3" data-mark-prefix="[PREFIX]" data-mark-suffix="[SUFFIX]" data-item-sep="[SEPARATOR]" data-display="inline">
+      <span data-type="item">list with all attributes (inline)</span>
     </span>...</p>
 
-    <p>...<span data-type="list" id="id3"><span data-type="title">list with all attributes and title</span><span data-type="LIST-TYPE" data-list-type="enumerated" data-bullet-style="open-circle" data-number-style="lower-alpha" start="3" data-mark-prefix="[PREFIX]" data-mark-suffix="[SUFFIX]" data-item-sep="[SEPARATOR]" data-display="IGNORE-ME">
-      <span data-type="item">and item</span>
+    <p>...<div data-type="list" id="id4"><div data-type="title">list with all attributes and title</div><div data-type="LIST-TYPE" data-list-type="enumerated" data-bullet-style="open-circle" data-number-style="lower-alpha" start="3" data-mark-prefix="[PREFIX]" data-mark-suffix="[SUFFIX]" data-item-sep="[SEPARATOR]" data-display="block">
+      <div data-type="item">and item</div>
+    </div></div>...</p>
+
+    <p>...<span data-type="list" id="id4-inline"><span data-type="title">list with all attributes and title</span><span data-type="LIST-TYPE" data-list-type="enumerated" data-bullet-style="open-circle" data-number-style="lower-alpha" start="3" data-mark-prefix="[PREFIX]" data-mark-suffix="[SUFFIX]" data-item-sep="[SEPARATOR]" data-display="inline">
+      <span data-type="item">and item (inline)</span>
     </span></span>...</p>
 
   </section>
@@ -188,8 +244,12 @@
 
   <section data-depth="2"><h2 data-type="title">Labeled-Item list:</h2>
 
-    <p>...<span data-type="list" data-list-type="labeled-item" id="id1">
-      <span data-type="item" data-label="with a label"> and item</span>
+    <p>...<div data-type="list" data-list-type="labeled-item" id="id1">
+      <div data-type="item" data-label="with a label"> and item</div>
+    </div>...</p>
+
+    <p>...<span data-type="list" data-list-type="labeled-item" id="id1-inline" data-display="inline">
+      <span data-type="item" data-label="with a label"> and item (inline)</span>
     </span>...</p>
 
   </section>


### PR DESCRIPTION
Previously lists in paras were all transformed into inline lists.  Now
checks against @display attribute and use divs instead of spans if it's
a block list.
