### PR TITLE
Add an id to footnote elements. Fixes #86

### DIFF
--- a/rhaptos/cnxmlutils/xsl/html5-to-cnxml.xsl
+++ b/rhaptos/cnxmlutils/xsl/html5-to-cnxml.xsl
@@ -845,7 +845,7 @@
 <xsl:template match="h:a[@data-type='footnote-ref']" mode="footnote"/>
 
 <xsl:template match="*[@data-type='footnote-number']">
-  <footnote>
+  <footnote id="{substring(@href, 2)}">
     <xsl:call-template name="get-footnote">
       <xsl:with-param name="name" select="substring(@href, 2)"/>
     </xsl:call-template>

--- a/rhaptos/cnxmlutils/xsl/test/footnote.html.cnxml
+++ b/rhaptos/cnxmlutils/xsl/test/footnote.html.cnxml
@@ -13,10 +13,14 @@
   <content>
     <para>...</para>
     <para>(observed
-      <footnote>Predicted by theory and first observed in 1983.</footnote>)
+      <footnote
+        id='footnote1'
+      >Predicted by theory and first observed in 1983.</footnote>)
     </para>
     <para>Gluons (conjectured
-      <footnote>Eight proposed—indirect evidence of existence. Underlie meson exchange.</footnote>)
+      <footnote
+        id='footnote2'
+      >Eight proposed—indirect evidence of existence. Underlie meson exchange.</footnote>)
     </para>
     <para>...</para>
   </content>


### PR DESCRIPTION
This uses the html id, not the original footnote id. Hopefully
that's not an issue.