### PR TITLE
fix footnotes so they are not double-numbered and more selectable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ rhaptos.cnxmlutils.egg-info/
 jing
 build/
 dist/
+
+/venv

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ addons:
     packages:
       - xsltproc
 install:
-  - python setup.py develop
+  - ./scripts/setup
 script:
-  - python setup.py test
+  - ./scripts/test
 notifications:
   email: false

--- a/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
+++ b/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
@@ -50,10 +50,10 @@
     <xsl:apply-templates select="c:content"/>
     <xsl:if test="c:content//c:footnote">
       <div data-type="footnote-refs">
-        <h3 data-type="footnote-title">Footnotes</h3>
-        <ol>
+        <h3 data-type="footnote-refs-title">Footnotes</h3>
+        <ul>
           <xsl:apply-templates select="//c:footnote" mode="footnote"/>
-        </ol>
+        </ul>
       </div>
     </xsl:if>
     <xsl:apply-templates select="c:glossary"/>
@@ -689,29 +689,34 @@
 </xsl:template>
 
 <xsl:template match="c:footnote">
-  <a data-type="{local-name()}-number">
-    <xsl:attribute name="name">
+  <sup data-type="footnote-number">
+    <xsl:attribute name="id">
       <xsl:text>footnote-ref</xsl:text><xsl:number level="any" count="c:footnote" format="1"/>
     </xsl:attribute>
-    <xsl:attribute name="href">
-      <xsl:text>#footnote</xsl:text><xsl:number level="any" count="c:footnote" format="1"/>
-    </xsl:attribute>
-    <sup><xsl:number level="any" count="c:footnote" format="1"/></sup>
-  </a>
+    <a data-type="footnote-link">
+      <xsl:attribute name="href">
+        <xsl:text>#footnote</xsl:text><xsl:number level="any" count="c:footnote" format="1"/>
+      </xsl:attribute>
+      <xsl:number level="any" count="c:footnote" format="1"/>
+    </a>
+  </sup>
 </xsl:template>
 
 <xsl:template match="c:footnote" mode="footnote">
-    <li>
-      <a data-type="{local-name()}-ref">
-        <xsl:attribute name="name">
-          <xsl:text>footnote</xsl:text><xsl:number level="any" count="c:footnote" format="1"/>
-        </xsl:attribute>
+    <li data-type="footnote-ref">
+      <xsl:attribute name="id">
+        <xsl:text>footnote</xsl:text><xsl:number level="any" count="c:footnote" format="1"/>
+      </xsl:attribute>
+      <a data-type="footnote-ref-link">
         <xsl:attribute name="href">
           <xsl:text>#footnote-ref</xsl:text><xsl:number level="any" count="c:footnote" format="1"/>
         </xsl:attribute>
         <xsl:number level="any" count="c:footnote" format="1"/>
       </a>
-      <xsl:text> </xsl:text><xsl:apply-templates/>
+      <xsl:text> </xsl:text>
+      <span data-type="footnote-ref-content">
+        <xsl:apply-templates/>
+      </span>
     </li>
 </xsl:template>
 

--- a/rhaptos/cnxmlutils/xsl/test/footnote.cnxml.html
+++ b/rhaptos/cnxmlutils/xsl/test/footnote.cnxml.html
@@ -16,24 +16,28 @@
   <p
     id='idm46678431438976'
   >(observed
-    <a
+    <sup
       data-type='footnote-number'
-      href='#footnote1'
-      name='footnote-ref1'
+      id='footnote-ref1'
     >
-      <sup>1</sup>
-    </a>)
+      <a
+        data-type='footnote-link'
+        href='#footnote1'
+      >1</a>
+    </sup>)
   </p>
   <p
     id='idm46678431437824'
   >Gluons (conjectured
-    <a
+    <sup
       data-type='footnote-number'
-      href='#footnote2'
-      name='footnote-ref2'
+      id='footnote-ref2'
     >
-      <sup>2</sup>
-    </a>)
+      <a
+        data-type='footnote-link'
+        href='#footnote2'
+      >2</a>
+    </sup>)
   </p>
   <p
     id='idm46678431436560'
@@ -41,46 +45,64 @@
   <p
     id='m42720-example'
   >
-    <a
+    <sup
       data-type='footnote-number'
-      href='#footnote3'
-      name='footnote-ref3'
+      id='footnote-ref3'
     >
-      <sup>3</sup>
-    </a>
+      <a
+        data-type='footnote-link'
+        href='#footnote3'
+      >3</a>
+    </sup>
   </p>
   <div
     data-type='footnote-refs'
   >
     <h3
-      data-type='footnote-title'
+      data-type='footnote-refs-title'
     >Footnotes</h3>
-    <ol>
-      <li>
+    <ul>
+      <li
+        data-type='footnote-ref'
+        id='footnote1'
+      >
         <a
-          data-type='footnote-ref'
+          data-type='footnote-ref-link'
           href='#footnote-ref1'
-          name='footnote1'
-        >1</a>Predicted by theory and first observed in 1983.
+        >1</a>
+        <span
+          data-type='footnote-ref-content'
+        >Predicted by theory and first observed in 1983.</span>
       </li>
-      <li>
+      <li
+        data-type='footnote-ref'
+        id='footnote2'
+      >
         <a
-          data-type='footnote-ref'
+          data-type='footnote-ref-link'
           href='#footnote-ref2'
-          name='footnote2'
-        >2</a>Eight proposed&#8212;indirect evidence of existence. Underlie meson exchange.
+        >2</a>
+        <span
+          data-type='footnote-ref-content'
+        >Eight proposed&#8212;indirect evidence of existence. Underlie meson exchange.</span>
       </li>
-      <li>
+      <li
+        data-type='footnote-ref'
+        id='footnote3'
+      >
         <a
-          data-type='footnote-ref'
+          data-type='footnote-ref-link'
           href='#footnote-ref3'
-          name='footnote3'
-        >3</a>  Stated values are according to the National Institute of Standards and Technology Reference on Constants, Units, and Uncertainty,
-        <a
-          href='http://www.physics.nist.gov/cuu'
-        >www.physics.nist.gov/cuu</a>(accessed May 18, 2012). Values in parentheses are the uncertainties in the last digits. Numbers without uncertainties are exact as defined.
+        >3</a>
+        <span
+          data-type='footnote-ref-content'
+        > Stated values are according to the National Institute of Standards and Technology Reference on Constants, Units, and Uncertainty,
+          <a
+            href='http://www.physics.nist.gov/cuu'
+          >www.physics.nist.gov/cuu</a>(accessed May 18, 2012). Values in parentheses are the uncertainties in the last digits. Numbers without uncertainties are exact as defined.
+        </span>
       </li>
-    </ol>
+    </ul>
   </div>
   <div
     data-type='glossary'

--- a/scripts/rebuild-tests
+++ b/scripts/rebuild-tests
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -e
+
+if [ ! "${CI}" = "true" ] # Skip when running Travis
+then
+  # Only activate the virtualenv if not already in one
+  if [ -z "${VIRTUAL_ENV}" ]
+  then
+    . ./venv/bin/activate
+  fi
+fi
+
+cd ./rhaptos/cnxmlutils/xsl/test
+python build.py $1 $2 $3 $4 $5

--- a/scripts/setup
+++ b/scripts/setup
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -e
+
+if [ ! "${CI}" = "true" ] # Skip when running Travis
+then
+  # Only activate the virtualenv if not already in one
+  if [ -z "${VIRTUAL_ENV}" ]
+  then
+    virtualenv ./venv
+    . ./venv/bin/activate
+  fi
+fi
+
+
+python setup.py develop

--- a/scripts/test
+++ b/scripts/test
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -e
+
+if [ ! "${CI}" = "true" ] # Skip when running Travis
+then
+  # Only activate the virtualenv if not already in one
+  if [ -z "${VIRTUAL_ENV}" ]
+  then
+    . ./venv/bin/activate
+  fi
+fi
+
+python setup.py test


### PR DESCRIPTION
(refs Connexions/webview#1460, Connexions/cnx-recipes#81 and Connexions/cnx-recipes#82)

This also adds attributes to elements so they can be removed later (via cnx-recipes).

# Screenshots

## New code

![image](https://cloud.githubusercontent.com/assets/253202/19454983/4e47f118-9489-11e6-9a4f-2901c610efb8.png)


## Old Code

![image](https://cloud.githubusercontent.com/assets/253202/19454972/3f8b9850-9489-11e6-9c4a-5755fb73e31c.png)

# Questions

- [ ] Should the whole "Footnotes" heading and title be discarded and just use `<ul data-type="footnote-refs"`?
  - [ ] If so, should "Glossary" be done the same way?