### PR TITLE
fix double-listing the footnotes

### DIFF
--- a/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
+++ b/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
@@ -51,7 +51,7 @@
     <xsl:if test="c:content//c:footnote">
       <div data-type="footnote-refs">
         <h3 data-type="footnote-refs-title">Footnotes</h3>
-        <ul>
+        <ul data-list-type="bulleted" data-bullet-style="none">
           <xsl:apply-templates select="//c:footnote" mode="footnote"/>
         </ul>
       </div>

--- a/rhaptos/cnxmlutils/xsl/test/build.py
+++ b/rhaptos/cnxmlutils/xsl/test/build.py
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """\
 Rebuilds the transformed files.

--- a/rhaptos/cnxmlutils/xsl/test/footnote.cnxml.html
+++ b/rhaptos/cnxmlutils/xsl/test/footnote.cnxml.html
@@ -61,7 +61,10 @@
     <h3
       data-type='footnote-refs-title'
     >Footnotes</h3>
-    <ul>
+    <ul
+      data-bullet-style='none'
+      data-list-type='bulleted'
+    >
       <li
         data-type='footnote-ref'
         id='footnote1'


### PR DESCRIPTION
This adds the proper attributes to turn footnotes into the following (refs https://github.com/Connexions/webview/pull/1460 )

# After

![image](https://cloud.githubusercontent.com/assets/253202/19899798/c003dd4e-a037-11e6-97a3-4ab4db5dbfd6.png)

# Before

![image](https://cloud.githubusercontent.com/assets/253202/19899870/f6a96fe4-a037-11e6-9c7d-00dcc89cc584.png)
