### PR TITLE
Nicer lists

### DIFF
--- a/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
+++ b/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
@@ -556,7 +556,6 @@
 <!-- Prefix these attributes with "data-" -->
 <xsl:template match="
      c:list/@bullet-style
-    |c:list/@number-style
     |c:list/@mark-prefix
     |c:list/@mark-suffix
     |c:list/@item-sep
@@ -602,6 +601,27 @@
 <xsl:template name="list-id-and-class">
   <xsl:apply-templates select="@id"/>
 </xsl:template>
+
+<xsl:template match="c:list/@number-style">
+  <xsl:variable name="typeCharacter">
+    <xsl:choose>
+      <xsl:when test=". = 'arabic'"></xsl:when>
+      <xsl:when test=". = 'upper-alpha'">A</xsl:when>
+      <xsl:when test=". = 'lower-alpha'">a</xsl:when>
+      <xsl:when test=". = 'upper-roman'">I</xsl:when>
+      <xsl:when test=". = 'lower-roman'">i</xsl:when>
+      <xsl:otherwise>
+        <xsl:message>BUG: Unknown c:list/@number-style="<xsl:value-of select="."/>"</xsl:message>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:variable>
+  <xsl:if test="'' != $typeCharacter">
+    <xsl:attribute name="type">
+      <xsl:value-of select="$typeCharacter"/>
+    </xsl:attribute>
+  </xsl:if>
+</xsl:template>
+
 
 <!-- ================= -->
 <!-- Block-level lists -->

--- a/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
+++ b/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
@@ -605,7 +605,7 @@
 <xsl:template match="c:list/@number-style">
   <xsl:variable name="typeCharacter">
     <xsl:choose>
-      <xsl:when test=". = 'arabic'"></xsl:when>
+      <xsl:when test=". = 'arabic'">1</xsl:when>
       <xsl:when test=". = 'upper-alpha'">A</xsl:when>
       <xsl:when test=". = 'lower-alpha'">a</xsl:when>
       <xsl:when test=". = 'upper-roman'">I</xsl:when>

--- a/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
+++ b/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
@@ -667,22 +667,6 @@
 <!-- Inline-level lists -->
 <!-- ================= -->
 
-<xsl:template mode="list-mode" match="c:para//c:list[not(@display)]|c:para//c:list[@display='block']">
-  <xsl:param name="convert-id-and-class"/>
-  <xsl:variable name="list-type">
-    <xsl:choose>
-      <xsl:when test="not(@list-type)">bulleted</xsl:when>
-      <xsl:otherwise><xsl:value-of select="@list-type"/></xsl:otherwise>
-    </xsl:choose>
-  </xsl:variable>
-  <div data-type="list" data-list-type="{$list-type}">
-    <xsl:if test="$convert-id-and-class">
-      <xsl:call-template name="list-id-and-class"/>
-    </xsl:if>
-    <xsl:apply-templates select="@*['id' != local-name()]|node()[not(self::c:title)]"/>
-  </div>
-</xsl:template>
-
 <xsl:template mode="list-mode" match="c:list[@display='inline']">
   <xsl:param name="convert-id-and-class"/>
   <xsl:variable name="list-type">
@@ -702,11 +686,6 @@
 <xsl:template match="c:list[@display='inline']/c:item">
   <span data-type="item"><xsl:apply-templates select="@*|node()"/></span>
 </xsl:template>
-
-<xsl:template match="c:para//c:list[@display='block']/c:item|c:para//c:list[not(@display)]/c:item">
-  <div data-type="item"><xsl:apply-templates select="@*|node()"/></div>
-</xsl:template>
-
 
 <!-- ========================= -->
 

--- a/rhaptos/cnxmlutils/xsl/test/code.cnxml
+++ b/rhaptos/cnxmlutils/xsl/test/code.cnxml
@@ -22,9 +22,8 @@
 
   <code id="id789" display="block"><label>the label</label><title>the title</title>with a title and label</code>
 
-  <code id="id7890" display="block" lang="JavaScript"><label>the label</label><title>the title</title>with a title and label
-[line 2]
-[line 3]</code>
+  <!-- Using 1 line because Travis and OSX use a different version libxml -->
+  <code id="id7890" display="block" lang="JavaScript"><label>the label</label><title>the title</title>with a title and label</code>
 
   <para id="idm45792189920736">Preformat element (much like a block of code but styled differently)</para>
 
@@ -32,9 +31,8 @@
 [line 2]          [after 10 spaces]
 [line 3]</preformat>
 
-  <preformat id="id4560"><title>the title</title>with a title
-[line 2]
-[line 3]</preformat>
+  <!-- Using 1 line because Travis and OSX use a different version libxml -->
+  <preformat id="id4560"><title>the title</title>with a title</preformat>
 
 
   <list id="idm45792189918144">

--- a/rhaptos/cnxmlutils/xsl/test/code.cnxml.html
+++ b/rhaptos/cnxmlutils/xsl/test/code.cnxml.html
@@ -69,7 +69,8 @@
       data-lang='JavaScript'
     >with a title and label
 [line 2]
-[line 3]</pre>
+[line 3]
+    </pre>
   </div>
   <p
     id='idm45792189920736'
@@ -88,7 +89,8 @@
     >the title</div>
     <pre>with a title
 [line 2]
-[line 3]</pre>
+[line 3]
+    </pre>
   </div>
   <ul
     id='idm45792189918144'

--- a/rhaptos/cnxmlutils/xsl/test/code.cnxml.html
+++ b/rhaptos/cnxmlutils/xsl/test/code.cnxml.html
@@ -56,6 +56,7 @@
       data-label='the label'
     >with a title and label</pre>
   </div>
+<!-- Using 1 line because Travis and OSX use a different version libxml -->
   <div
     data-type='code'
     id='id7890'
@@ -67,10 +68,7 @@
       data-display='block'
       data-label='the label'
       data-lang='JavaScript'
-    >with a title and label
-[line 2]
-[line 3]
-    </pre>
+    >with a title and label</pre>
   </div>
   <p
     id='idm45792189920736'
@@ -80,6 +78,7 @@
   >[line 1]
 [line 2]          [after 10 spaces]
 [line 3]</pre>
+<!-- Using 1 line because Travis and OSX use a different version libxml -->
   <div
     data-type='code'
     id='id4560'
@@ -87,10 +86,7 @@
     <div
       data-type='title'
     >the title</div>
-    <pre>with a title
-[line 2]
-[line 3]
-    </pre>
+    <pre>with a title</pre>
   </div>
   <ul
     id='idm45792189918144'

--- a/rhaptos/cnxmlutils/xsl/test/code.html
+++ b/rhaptos/cnxmlutils/xsl/test/code.html
@@ -85,9 +85,7 @@
     <div
       data-type='title'
     >the title</div>
-    <pre>with a title
-[line 2]
-[line 3]</pre>
+    <pre>with a title</pre>
   </div>
   <ul
     id='idm45792189918144'

--- a/rhaptos/cnxmlutils/xsl/test/code.html
+++ b/rhaptos/cnxmlutils/xsl/test/code.html
@@ -67,9 +67,7 @@
       data-display='block'
       data-label='the label'
       data-lang='JavaScript'
-    >with a title and label
-[line 2]
-[line 3]</pre>
+    >with a title and label</pre>
   </div>
   <p
     id='idm45792189920736'

--- a/rhaptos/cnxmlutils/xsl/test/code.html.cnxml
+++ b/rhaptos/cnxmlutils/xsl/test/code.html.cnxml
@@ -55,8 +55,6 @@
     >
       <label>the label</label>
       <title>the title</title>with a title and label
-[line 2]
-[line 3]
     </code>
     <para
       id='idm45792189920736'

--- a/rhaptos/cnxmlutils/xsl/test/code.html.cnxml
+++ b/rhaptos/cnxmlutils/xsl/test/code.html.cnxml
@@ -1,32 +1,85 @@
 <?xml version="1.0" encoding="utf-8"?>
-<document xmlns="http://cnx.rice.edu/cnxml" xmlns:md="http://cnx.rice.edu/mdml/0.4" xmlns:md1="http://cnx.rice.edu/mdml" xmlns:bib="http://bibtexml.sf.net/" xmlns:m="http://www.w3.org/1998/Math/MathML" xmlns:q="http://cnx.rice.edu/qml/1.0" xmlns:data="http://www.w3.org/TR/html5/dom.html#custom-data-attribute" cnxml-version="0.7"><title>Test Module</title><content>
-  
-  <code display="block" id="idc23423423">[line 1]
-[line 2]          [after 10 spaces]
-[line 3]</code>
-  <para id="idm45792189928240">...
-    <code>[some text]          [after 10 spaces]</code>...
-  </para>
-  <para id="id2342345">
-    <code display="inline">Inline code where it would normally be a block</code>
-  </para>
-  <code display="block" lang="JavaScript" id="id34556">with a language attribute</code>
-  <code id="id456" display="block"><title>the title</title>with a title</code>
-  <code id="id789" display="block"><label>the label</label><title>the title</title>with a title and label</code>
-  <code id="id7890" display="block" lang="JavaScript"><label>the label</label><title>the title</title>with a title and label
-[line 2]
-[line 3]</code>
-  <para id="idm45792189920736">Preformat element (much like a block of code but styled differently)</para>
-  <code id="idm45889741367328">[line 1]
-[line 2]          [after 10 spaces]
-[line 3]</code>
 
-  <code id="id4560"><title>the title</title>with a title
-[line 2]
+<document
+  cnxml-version='0.7'
+  xmlns='http://cnx.rice.edu/cnxml'
+  xmlns:bib='http://bibtexml.sf.net/'
+  xmlns:data='http://www.w3.org/TR/html5/dom.html#custom-data-attribute'
+  xmlns:m='http://www.w3.org/1998/Math/MathML'
+  xmlns:md='http://cnx.rice.edu/mdml/0.4'
+  xmlns:md1='http://cnx.rice.edu/mdml'
+  xmlns:q='http://cnx.rice.edu/qml/1.0'
+>
+  <title>Test Module</title>
+  <content>
+    <code
+      display='block'
+      id='idc23423423'
+    >[line 1]
+[line 2]          [after 10 spaces]
 [line 3]</code>
-  <list list-type="bulleted" id="idm45792189918144">
-    <item>
-      <code>inline code; should not be a blockish pre</code>
-    </item>
-  </list>
-</content></document>
+    <para
+      id='idm45792189928240'
+    >...
+      <code>[some text]          [after 10 spaces]</code>...
+    </para>
+    <para
+      id='id2342345'
+    >
+      <code
+        display='inline'
+      >Inline code where it would normally be a block</code>
+    </para>
+    <code
+      display='block'
+      id='id34556'
+      lang='JavaScript'
+    >with a language attribute</code>
+    <code
+      display='block'
+      id='id456'
+    >
+      <title>the title</title>with a title
+    </code>
+    <code
+      display='block'
+      id='id789'
+    >
+      <label>the label</label>
+      <title>the title</title>with a title and label
+    </code>
+    <code
+      display='block'
+      id='id7890'
+      lang='JavaScript'
+    >
+      <label>the label</label>
+      <title>the title</title>with a title and label
+[line 2]
+[line 3]
+    </code>
+    <para
+      id='idm45792189920736'
+    >Preformat element (much like a block of code but styled differently)</para>
+    <code
+      id='idm45889741367328'
+    >[line 1]
+[line 2]          [after 10 spaces]
+[line 3]</code>
+    <code
+      id='id4560'
+    >
+      <title>the title</title>with a title
+[line 2]
+[line 3]
+    </code>
+    <list
+      id='idm45792189918144'
+      list-type='bulleted'
+    >
+      <item>
+        <code>inline code; should not be a blockish pre</code>
+      </item>
+    </list>
+  </content>
+</document>

--- a/rhaptos/cnxmlutils/xsl/test/code.html.cnxml
+++ b/rhaptos/cnxmlutils/xsl/test/code.html.cnxml
@@ -68,8 +68,6 @@
       id='id4560'
     >
       <title>the title</title>with a title
-[line 2]
-[line 3]
     </code>
     <list
       id='idm45792189918144'

--- a/rhaptos/cnxmlutils/xsl/test/definition.cnxml.html
+++ b/rhaptos/cnxmlutils/xsl/test/definition.cnxml.html
@@ -1753,6 +1753,7 @@ To separate something by 'mechanical means', means that there is no chemical pro
         <ol
           class='stepwise'
           id='id7432'
+          type='1'
         >
           <li
             data-label='Write down the names of each element or ion in the compound'
@@ -1795,6 +1796,7 @@ To separate something by 'mechanical means', means that there is no chemical pro
         <ol
           class='stepwise'
           id='id874452'
+          type='1'
         >
           <li
             data-label='Write the symbol for each element or compound'

--- a/rhaptos/cnxmlutils/xsl/test/definition.cnxml.html
+++ b/rhaptos/cnxmlutils/xsl/test/definition.cnxml.html
@@ -44,36 +44,28 @@
     <p
       id='id0132'
     >Some of the properties of matter that you should know are:</p>
-    <div
-      data-list-type='bulleted'
-      data-type='list'
+    <ul
       id='lid825'
     >
-      <div
+      <li
         data-label='Strength'
-        data-type='item'
-      >Materials can be strong and resist bending (e.g. iron rods, cement) or weak (e.g. fabrics)</div>
-      <div
+      >Materials can be strong and resist bending (e.g. iron rods, cement) or weak (e.g. fabrics)</li>
+      <li
         data-label='Thermal and electrical conductivity'
-        data-type='item'
-      >Materials that conduct heat (e.g. metals) are called thermal conductors. Materials that conduct electricity are electrical conductors.</div>
-      <div
+      >Materials that conduct heat (e.g. metals) are called thermal conductors. Materials that conduct electricity are electrical conductors.</li>
+      <li
         data-label='Brittle, malleable or ductile'
-        data-type='item'
-      >Brittle materials break easily. Materials that are malleable can be easily formed into different shapes. Ductile materials are able to be formed into long wires.</div>
-      <div
+      >Brittle materials break easily. Materials that are malleable can be easily formed into different shapes. Ductile materials are able to be formed into long wires.</li>
+      <li
         data-label='Magnetic or non-magnetic'
-        data-type='item'
-      >Magnetic materials have a magnetic field.</div>
-      <div
+      >Magnetic materials have a magnetic field.</li>
+      <li
         data-label='Density'
-        data-type='item'
-      >Density is the mass per unit volume. An example of a dense material is concrete.</div>
-      <div
+      >Density is the mass per unit volume. An example of a dense material is concrete.</li>
+      <li
         data-label='Boiling and melting points'
-        data-type='item'
-      >The boiling and melting points of substance help us to classify substances as solids, liquids or gases at a specific temperature.</div>
-    </div>
+      >The boiling and melting points of substance help us to classify substances as solids, liquids or gases at a specific temperature.</li>
+    </ul>
     <p
       id='id62556'
     >The diagram below shows one way in which matter can be classified (grouped) according to its different properties. As you read further in this chapter, you will see that there are also other ways of classifying materials, for example according to whether or not they are good electrical conductors.</p>
@@ -255,25 +247,15 @@ To separate something by 'mechanical means', means that there is no chemical pro
         <p
           id='eip-353'
         >For each of the following mixtures state whether it is a homogenous or a heterogenous mixture:</p>
-        <div
-          data-list-type='enumerated'
-          data-type='list'
+        <ol
           id='eip-id1167649056231'
           type='a'
         >
-          <div
-            data-type='item'
-          >sugar and water</div>
-          <div
-            data-type='item'
-          >flour and iron filings (small pieces of iron)</div>
-          <div
-            data-type='item'
-          >flour and baking powder</div>
-          <div
-            data-type='item'
-          >smarties, jelly tots and peppermints</div>
-        </div>
+          <li>sugar and water</li>
+          <li>flour and iron filings (small pieces of iron)</li>
+          <li>flour and baking powder</li>
+          <li>smarties, jelly tots and peppermints</li>
+        </ol>
       </div>
       <div
         data-type='solution'
@@ -664,21 +646,13 @@ To separate something by 'mechanical means', means that there is no chemical pro
           <p
             id='eip-457'
           >For each of the following substances state whether it is a pure substance or a mixture. If it is a mixture, is it homogenous or heterogenous? If it is a pure substance is it an element or a compound?</p>
-          <div
-            data-list-type='enumerated'
-            data-type='list'
+          <ol
             id='eip-id1167351497334'
             type='a'
           >
-            <div
-              data-type='item'
-            >Blood</div>
-            <div
-              data-type='item'
-            >Argon</div>
-            <div
-              data-type='item'
-            >Silicon dioxide (
+            <li>Blood</li>
+            <li>Argon</li>
+            <li>Silicon dioxide (
               <math
                 xmlns='http://www.w3.org/1998/Math/MathML'
               >
@@ -687,11 +661,9 @@ To separate something by 'mechanical means', means that there is no chemical pro
                   <mn>2</mn>
                 </msub>
               </math>)
-            </div>
-            <div
-              data-type='item'
-            >Sand and stones</div>
-          </div>
+            </li>
+            <li>Sand and stones</li>
+          </ol>
         </div>
         <div
           data-type='solution'
@@ -715,35 +687,21 @@ To separate something by 'mechanical means', means that there is no chemical pro
           data-type='title'
         >Activity: Using models to represent substances</span>Use coloured balls and sticks to represent elements and compounds. Some examples that you can try to build are:
       </p>
-      <div
-        data-list-type='bulleted'
-        data-type='list'
+      <ul
         id='eip-id1166921187210'
       >
-        <div
-          data-type='item'
-        >Hydrogen</div>
-        <div
-          data-type='item'
-        >Oxygen</div>
-        <div
-          data-type='item'
-        >Nitrogen</div>
-        <div
-          data-type='item'
-        >Neon</div>
-        <div
-          data-type='item'
-        >Sodium chloride (salt,
+        <li>Hydrogen</li>
+        <li>Oxygen</li>
+        <li>Nitrogen</li>
+        <li>Neon</li>
+        <li>Sodium chloride (salt,
           <math
             xmlns='http://www.w3.org/1998/Math/MathML'
           >
             <mi>NaCl</mi>
           </math>)
-        </div>
-        <div
-          data-type='item'
-        >Potassium permanganate (
+        </li>
+        <li>Potassium permanganate (
           <math
             xmlns='http://www.w3.org/1998/Math/MathML'
           >
@@ -754,10 +712,8 @@ To separate something by 'mechanical means', means that there is no chemical pro
               <mn>4</mn>
             </msub>
           </math>)
-        </div>
-        <div
-          data-type='item'
-        >Water (
+        </li>
+        <li>Water (
           <math
             xmlns='http://www.w3.org/1998/Math/MathML'
           >
@@ -771,17 +727,15 @@ To separate something by 'mechanical means', means that there is no chemical pro
               mathvariant='normal'
             >O</mi>
           </math>)
-        </div>
-        <div
-          data-type='item'
-        >Iron sulphide (
+        </li>
+        <li>Iron sulphide (
           <math
             xmlns='http://www.w3.org/1998/Math/MathML'
           >
             <mi>FeS</mi>
           </math>)
-        </div>
-      </div>
+        </li>
+      </ul>
       <p>Think about the way that we represent substances microscopically. Would you use just one ball to represent an element or many? Why?</p>
       <section
         data-depth='3'
@@ -1710,15 +1664,11 @@ To separate something by 'mechanical means', means that there is no chemical pro
         <p
           id='eip-870'
         >What is the chemical name for</p>
-        <div
-          data-list-type='enumerated'
-          data-type='list'
+        <ol
           id='id734'
           type='a'
         >
-          <div
-            data-type='item'
-          >
+          <li>
             <math
               xmlns='http://www.w3.org/1998/Math/MathML'
             >
@@ -1730,10 +1680,8 @@ To separate something by 'mechanical means', means that there is no chemical pro
                 <mn>4</mn>
               </msub>
             </math>
-          </div>
-          <div
-            data-type='item'
-          >
+          </li>
+          <li>
             <math
               xmlns='http://www.w3.org/1998/Math/MathML'
             >
@@ -1743,8 +1691,8 @@ To separate something by 'mechanical means', means that there is no chemical pro
               </msub>
               <mi>Cl</mi>
             </math>
-          </div>
-        </div>
+          </li>
+        </ol>
       </div>
       <div
         data-type='solution'
@@ -1775,19 +1723,13 @@ To separate something by 'mechanical means', means that there is no chemical pro
         <p
           id='eip-535'
         >Write the chemical formulae for:</p>
-        <div
-          data-list-type='enumerated'
-          data-type='list'
+        <ol
           id='id87432'
           type='a'
         >
-          <div
-            data-type='item'
-          >sodium sulphate</div>
-          <div
-            data-type='item'
-          >potassium chromate</div>
-        </div>
+          <li>sodium sulphate</li>
+          <li>potassium chromate</li>
+        </ol>
       </div>
       <div
         data-type='solution'
@@ -2396,25 +2338,15 @@ To separate something by 'mechanical means', means that there is no chemical pro
         <p
           id='eip-252'
         >For each of the following substances state whether they are metals, metalloids or non-metals, using their position on the periodic table.</p>
-        <div
-          data-list-type='enumerated'
-          data-type='list'
+        <ol
           id='eip-id1170734629720'
           type='a'
         >
-          <div
-            data-type='item'
-          >Oxygen</div>
-          <div
-            data-type='item'
-          >Arsenic</div>
-          <div
-            data-type='item'
-          >Vanadium</div>
-          <div
-            data-type='item'
-          >Potassium</div>
-        </div>
+          <li>Oxygen</li>
+          <li>Arsenic</li>
+          <li>Vanadium</li>
+          <li>Potassium</li>
+        </ol>
       </div>
       <div
         data-type='solution'
@@ -2445,25 +2377,15 @@ To separate something by 'mechanical means', means that there is no chemical pro
         <p
           id='eip-25442'
         >For each of the following substances state whether they are metals, metalloids or non-metals, using the information given.</p>
-        <div
-          data-list-type='enumerated'
-          data-type='list'
+        <ol
           id='eip-id1170742635239'
           type='a'
         >
-          <div
-            data-type='item'
-          >Aluminium in a cooking pot</div>
-          <div
-            data-type='item'
-          >Silicon in a computer chip</div>
-          <div
-            data-type='item'
-          >Plastic insulation around a wire</div>
-          <div
-            data-type='item'
-          >Silver jewellery</div>
-        </div>
+          <li>Aluminium in a cooking pot</li>
+          <li>Silicon in a computer chip</li>
+          <li>Plastic insulation around a wire</li>
+          <li>Silver jewellery</li>
+        </ol>
       </div>
       <div
         data-type='solution'

--- a/rhaptos/cnxmlutils/xsl/test/definition.cnxml.html
+++ b/rhaptos/cnxmlutils/xsl/test/definition.cnxml.html
@@ -257,9 +257,9 @@ To separate something by 'mechanical means', means that there is no chemical pro
         >For each of the following mixtures state whether it is a homogenous or a heterogenous mixture:</p>
         <div
           data-list-type='enumerated'
-          data-number-style='lower-alpha'
           data-type='list'
           id='eip-id1167649056231'
+          type='a'
         >
           <div
             data-type='item'
@@ -280,8 +280,8 @@ To separate something by 'mechanical means', means that there is no chemical pro
         id='eip-602'
       >
         <ol
-          data-number-style='lower-alpha'
           id='eip-id7325184'
+          type='a'
         >
           <li>This is a homogenous mixture since we cannot see the sugar in the water. Also, the two components are mixed uniformly.</li>
           <li>This is a heterogenous mixture since we are able to make out the pieces of iron in the flour. In this mixture there may be places where there are a lot of iron filings and places where there is more flour, so it is not uniformly mixed.</li>
@@ -323,8 +323,8 @@ To separate something by 'mechanical means', means that there is no chemical pro
           >mixtures</em>?
           <ol
             data-display='block'
-            data-number-style='lower-alpha'
             id='id63170'
+            type='a'
           >
             <li
               id='uid18'
@@ -666,9 +666,9 @@ To separate something by 'mechanical means', means that there is no chemical pro
           >For each of the following substances state whether it is a pure substance or a mixture. If it is a mixture, is it homogenous or heterogenous? If it is a pure substance is it an element or a compound?</p>
           <div
             data-list-type='enumerated'
-            data-number-style='lower-alpha'
             data-type='list'
             id='eip-id1167351497334'
+            type='a'
           >
             <div
               data-type='item'
@@ -698,8 +698,8 @@ To separate something by 'mechanical means', means that there is no chemical pro
           id='eip-62'
         >
           <ol
-            data-number-style='lower-alpha'
             id='eip-id1167366034146'
+            type='a'
           >
             <li>Blood is a mixture since it is made up of many different compounds and substances. Blood is a homogenous mixture since you cannot see the individual components and the components are uniformly distributed.</li>
             <li>Argon is a pure substance. Argon is an element since we can find it on the periodic table.</li>
@@ -879,8 +879,8 @@ To separate something by 'mechanical means', means that there is no chemical pro
           >In each of the following cases, say whether the substance is an element, a mixture or a compound.
             <ol
               data-display='block'
-              data-number-style='lower-alpha'
               id='id63912'
+              type='a'
             >
               <li
                 id='uid30'
@@ -1712,9 +1712,9 @@ To separate something by 'mechanical means', means that there is no chemical pro
         >What is the chemical name for</p>
         <div
           data-list-type='enumerated'
-          data-number-style='lower-alpha'
           data-type='list'
           id='id734'
+          type='a'
         >
           <div
             data-type='item'
@@ -1752,7 +1752,6 @@ To separate something by 'mechanical means', means that there is no chemical pro
       >
         <ol
           class='stepwise'
-          data-number-style='arabic'
           id='id7432'
         >
           <li
@@ -1777,9 +1776,9 @@ To separate something by 'mechanical means', means that there is no chemical pro
         >Write the chemical formulae for:</p>
         <div
           data-list-type='enumerated'
-          data-number-style='lower-alpha'
           data-type='list'
           id='id87432'
+          type='a'
         >
           <div
             data-type='item'
@@ -1795,7 +1794,6 @@ To separate something by 'mechanical means', means that there is no chemical pro
       >
         <ol
           class='stepwise'
-          data-number-style='arabic'
           id='id874452'
         >
           <li
@@ -1937,8 +1935,8 @@ To separate something by 'mechanical means', means that there is no chemical pro
           </math>.
           <ol
             data-display='block'
-            data-number-style='lower-alpha'
             id='id65148'
+            type='a'
           >
             <li
               id='uid48'
@@ -1972,8 +1970,8 @@ To separate something by 'mechanical means', means that there is no chemical pro
         >Give the name of each of the following substances.
           <ol
             data-display='block'
-            data-number-style='lower-alpha'
             id='id65189'
+            type='a'
           >
             <li
               id='uid51'
@@ -2058,8 +2056,8 @@ To separate something by 'mechanical means', means that there is no chemical pro
         >Give the chemical formula for each of the following compounds.
           <ol
             data-display='block'
-            data-number-style='lower-alpha'
             id='id65338'
+            type='a'
           >
             <li
               id='uid58'
@@ -2112,8 +2110,8 @@ To separate something by 'mechanical means', means that there is no chemical pro
           </figure>
           <ol
             data-display='block'
-            data-number-style='lower-alpha'
             id='id65426'
+            type='a'
           >
             <li
               id='uid64'
@@ -2398,9 +2396,9 @@ To separate something by 'mechanical means', means that there is no chemical pro
         >For each of the following substances state whether they are metals, metalloids or non-metals, using their position on the periodic table.</p>
         <div
           data-list-type='enumerated'
-          data-number-style='lower-alpha'
           data-type='list'
           id='eip-id1170734629720'
+          type='a'
         >
           <div
             data-type='item'
@@ -2421,8 +2419,8 @@ To separate something by 'mechanical means', means that there is no chemical pro
         id='eip-149'
       >
         <ol
-          data-number-style='lower-alpha'
           id='eip-id1170750216596'
+          type='a'
         >
           <li>Oxygen is on the right of the zigzag line and so is a non-metal.</li>
           <li>Arsenic is on the zigzag line and is a metalloid.</li>
@@ -2447,9 +2445,9 @@ To separate something by 'mechanical means', means that there is no chemical pro
         >For each of the following substances state whether they are metals, metalloids or non-metals, using the information given.</p>
         <div
           data-list-type='enumerated'
-          data-number-style='lower-alpha'
           data-type='list'
           id='eip-id1170742635239'
+          type='a'
         >
           <div
             data-type='item'
@@ -2470,8 +2468,8 @@ To separate something by 'mechanical means', means that there is no chemical pro
         id='eip-1455'
       >
         <ol
-          data-number-style='lower-alpha'
           id='eip-id1170755988427'
+          type='a'
         >
           <li>A cooking pot needs to be able to conduct heat and so the aluminium used must be a metal.</li>
           <li>Computer chips rely on semi-conductors and all metalloids are semiconductors. So silicon is a metalloid.</li>

--- a/rhaptos/cnxmlutils/xsl/test/label.cnxml
+++ b/rhaptos/cnxmlutils/xsl/test/label.cnxml
@@ -11,13 +11,5 @@
     </item>
   </list>
 
-  <!-- Commenting this line because Travis and OSX use a different version libxml -->
-  <!-- <list id="idm45791213868720">
-    <item>
-        <label>hello <emphasis>there</emphasis></label>
-      item
-    </item>
-  </list> -->
-
 </content>
 </document>

--- a/rhaptos/cnxmlutils/xsl/test/label.cnxml
+++ b/rhaptos/cnxmlutils/xsl/test/label.cnxml
@@ -11,12 +11,13 @@
     </item>
   </list>
 
-  <list id="idm45791213868720">
+  <!-- Commenting this line because Travis and OSX use a different version libxml -->
+  <!-- <list id="idm45791213868720">
     <item>
         <label>hello <emphasis>there</emphasis></label>
       item
     </item>
-  </list>
+  </list> -->
 
 </content>
 </document>

--- a/rhaptos/cnxmlutils/xsl/test/label.cnxml.html
+++ b/rhaptos/cnxmlutils/xsl/test/label.cnxml.html
@@ -17,11 +17,17 @@
       data-label='label'
     >item</li>
   </ul>
-  <ul
-    id='idm45791213868720'
-  >
-    <li
-      data-label='hello&#10;          there&#10;        '
-    >item</li>
-  </ul>
+<!-- Commenting this line because Travis and OSX use a different version libxml -->
+<!-- 
+  
+<list id="idm45791213868720">
+<item>
+<label>hello
+<emphasis>there
+</emphasis>
+</label>
+item
+</item>
+</list>
+  -->
 </body>

--- a/rhaptos/cnxmlutils/xsl/test/label.cnxml.html
+++ b/rhaptos/cnxmlutils/xsl/test/label.cnxml.html
@@ -21,7 +21,7 @@
     id='idm45791213868720'
   >
     <li
-      data-label='hello there'
+      data-label='hello&#10;          there&#10;        '
     >item</li>
   </ul>
 </body>

--- a/rhaptos/cnxmlutils/xsl/test/label.cnxml.html
+++ b/rhaptos/cnxmlutils/xsl/test/label.cnxml.html
@@ -17,17 +17,4 @@
       data-label='label'
     >item</li>
   </ul>
-<!-- Commenting this line because Travis and OSX use a different version libxml -->
-<!-- 
-  
-<list id="idm45791213868720">
-<item>
-<label>hello
-<emphasis>there
-</emphasis>
-</label>
-item
-</item>
-</list>
-  -->
 </body>

--- a/rhaptos/cnxmlutils/xsl/test/list.cnxml
+++ b/rhaptos/cnxmlutils/xsl/test/list.cnxml
@@ -2,6 +2,25 @@
 <document xmlns="http://cnx.rice.edu/cnxml" xmlns:bib="http://bibtexml.sf.net/" xmlns:md="http://cnx.rice.edu/mdml/0.4" xmlns:md1="http://cnx.rice.edu/mdml" xmlns:q="http://cnx.rice.edu/qml/1.0" id="idm45159773362944" cnxml-version="0.7" module-id="mXXXX">
   <title>Test Module</title>
   <content>
+    <list id="list-enumerated" list-type="enumerated">
+      <item>item</item>
+    </list>
+    <list id="list-arabic" list-type="enumerated" number-style="arabic">
+      <item>item</item>
+    </list>
+    <list id="list-upper-alpha" list-type="enumerated" number-style="upper-alpha">
+      <item>item</item>
+    </list>
+    <list id="list-lower-alpha" list-type="enumerated" number-style="lower-alpha">
+      <item>item</item>
+    </list>
+    <list id="list-upper-roman" list-type="enumerated" number-style="upper-roman">
+      <item>item</item>
+    </list>
+    <list id="list-lower-roman" list-type="enumerated" number-style="lower-roman">
+      <item>item</item>
+    </list>
+
     <section id="idm45159773377600">
       <title>Lists NOT in a paragraph</title>
       <list id="idm45159773376592">

--- a/rhaptos/cnxmlutils/xsl/test/list.cnxml
+++ b/rhaptos/cnxmlutils/xsl/test/list.cnxml
@@ -21,6 +21,12 @@
       <item>item</item>
     </list>
 
+    <para id="para-list-enumerated">
+      <list id="para-list-enumerated-list" list-type="enumerated" number-style="upper-alpha" start-value="3">
+        <item>item</item>
+      </list>
+    </para>
+
     <section id="idm45159773377600">
       <title>Lists NOT in a paragraph</title>
       <list id="idm45159773376592">

--- a/rhaptos/cnxmlutils/xsl/test/list.cnxml.html
+++ b/rhaptos/cnxmlutils/xsl/test/list.cnxml.html
@@ -17,6 +17,7 @@
   </ol>
   <ol
     id='list-arabic'
+    type='1'
   >
     <li>item</li>
   </ol>

--- a/rhaptos/cnxmlutils/xsl/test/list.cnxml.html
+++ b/rhaptos/cnxmlutils/xsl/test/list.cnxml.html
@@ -10,6 +10,40 @@
   <div
     data-type='document-title'
   >Test Module</div>
+  <ol
+    id='list-enumerated'
+  >
+    <li>item</li>
+  </ol>
+  <ol
+    id='list-arabic'
+  >
+    <li>item</li>
+  </ol>
+  <ol
+    id='list-upper-alpha'
+    type='A'
+  >
+    <li>item</li>
+  </ol>
+  <ol
+    id='list-lower-alpha'
+    type='a'
+  >
+    <li>item</li>
+  </ol>
+  <ol
+    id='list-upper-roman'
+    type='I'
+  >
+    <li>item</li>
+  </ol>
+  <ol
+    id='list-lower-roman'
+    type='i'
+  >
+    <li>item</li>
+  </ol>
   <section
     data-depth='1'
     id='idm45159773377600'
@@ -68,8 +102,8 @@
         data-item-sep='[SEPARATOR]'
         data-mark-prefix='[PREFIX]'
         data-mark-suffix='[SUFFIX]'
-        data-number-style='lower-alpha'
         id='idm45159773271584'
+        type='a'
       >
         <li>list with all attributes</li>
       </ol>
@@ -400,10 +434,10 @@
         data-list-type='enumerated'
         data-mark-prefix='[PREFIX]'
         data-mark-suffix='[SUFFIX]'
-        data-number-style='lower-alpha'
         data-type='list'
         id='idm45159773213472'
         start='3'
+        type='a'
       >
         <div
           data-type='item'
@@ -420,9 +454,9 @@
           data-list-type='enumerated'
           data-mark-prefix='[PREFIX]'
           data-mark-suffix='[SUFFIX]'
-          data-number-style='lower-alpha'
           data-type='list'
           start='3'
+          type='a'
         >
           <span
             data-type='item'
@@ -446,9 +480,9 @@
           data-list-type='enumerated'
           data-mark-prefix='[PREFIX]'
           data-mark-suffix='[SUFFIX]'
-          data-number-style='lower-alpha'
           data-type='list'
           start='3'
+          type='a'
         >
           <div
             data-type='item'
@@ -472,9 +506,9 @@
             data-list-type='enumerated'
             data-mark-prefix='[PREFIX]'
             data-mark-suffix='[SUFFIX]'
-            data-number-style='lower-alpha'
             data-type='list'
             start='3'
+            type='a'
           >
             <span
               data-type='item'
@@ -739,10 +773,10 @@
         data-list-type='enumerated'
         data-mark-prefix='[PREFIX]'
         data-mark-suffix='[SUFFIX]'
-        data-number-style='lower-alpha'
         data-type='list'
         id='idm45159773155712'
         start='3'
+        type='a'
       >
         <div
           data-type='item'
@@ -759,9 +793,9 @@
           data-list-type='enumerated'
           data-mark-prefix='[PREFIX]'
           data-mark-suffix='[SUFFIX]'
-          data-number-style='lower-alpha'
           data-type='list'
           start='3'
+          type='a'
         >
           <span
             data-type='item'
@@ -785,9 +819,9 @@
           data-list-type='enumerated'
           data-mark-prefix='[PREFIX]'
           data-mark-suffix='[SUFFIX]'
-          data-number-style='lower-alpha'
           data-type='list'
           start='3'
+          type='a'
         >
           <div
             data-type='item'
@@ -811,9 +845,9 @@
             data-list-type='enumerated'
             data-mark-prefix='[PREFIX]'
             data-mark-suffix='[SUFFIX]'
-            data-number-style='lower-alpha'
             data-type='list'
             start='3'
+            type='a'
           >
             <span
               data-type='item'

--- a/rhaptos/cnxmlutils/xsl/test/list.cnxml.html
+++ b/rhaptos/cnxmlutils/xsl/test/list.cnxml.html
@@ -45,6 +45,13 @@
   >
     <li>item</li>
   </ol>
+  <ol
+    id='para-list-enumerated-list'
+    start='3'
+    type='A'
+  >
+    <li>item</li>
+  </ol>
   <section
     data-depth='1'
     id='idm45159773377600'
@@ -284,15 +291,11 @@
     <p
       id='idm45159773233392'
     >...</p>
-    <div
-      data-list-type='bulleted'
-      data-type='list'
+    <ul
       id='idm45159773232832'
     >
-      <div
-        data-type='item'
-      >list with item</div>
-    </div>
+      <li>list with item</li>
+    </ul>
     <p>...</p>
     <p
       id='idm45159773231600'
@@ -317,14 +320,9 @@
       <div
         data-type='title'
       >and title</div>
-      <div
-        data-list-type='bulleted'
-        data-type='list'
-      >
-        <div
-          data-type='item'
-        >and item</div>
-      </div>
+      <ul>
+        <li>and item</li>
+      </ul>
     </div>
     <p>...</p>
     <p
@@ -360,15 +358,11 @@
       <p
         id='idm45159773223200'
       >...</p>
-      <div
-        data-list-type='bulleted'
-        data-type='list'
+      <ul
         id='idm45159773222640'
       >
-        <div
-          data-type='item'
-        >and item</div>
-      </div>
+        <li>and item</li>
+      </ul>
       <p>...</p>
       <p
         id='idm45159773221440'
@@ -393,14 +387,9 @@
         <div
           data-type='title'
         >and title</div>
-        <div
-          data-list-type='bulleted'
-          data-type='list'
-        >
-          <div
-            data-type='item'
-          >and item</div>
-        </div>
+        <ul>
+          <li>and item</li>
+        </ul>
       </div>
       <p>...</p>
       <p
@@ -429,21 +418,17 @@
       <p
         id='idm45159773214032'
       >...</p>
-      <div
+      <ol
         data-element-type='LIST-TYPE'
         data-item-sep='[SEPARATOR]'
-        data-list-type='enumerated'
         data-mark-prefix='[PREFIX]'
         data-mark-suffix='[SUFFIX]'
-        data-type='list'
         id='idm45159773213472'
         start='3'
         type='a'
       >
-        <div
-          data-type='item'
-        >list with all attributes</div>
-      </div>
+        <li>list with all attributes</li>
+      </ol>
       <p>...</p>
       <p
         id='idm45159773210384'
@@ -474,21 +459,17 @@
         <div
           data-type='title'
         >list with all attributes and title</div>
-        <div
+        <ol
           data-display='block'
           data-element-type='LIST-TYPE'
           data-item-sep='[SEPARATOR]'
-          data-list-type='enumerated'
           data-mark-prefix='[PREFIX]'
           data-mark-suffix='[SUFFIX]'
-          data-type='list'
           start='3'
           type='a'
         >
-          <div
-            data-type='item'
-          >and item</div>
-        </div>
+          <li>and item</li>
+        </ol>
       </div>
       <p>...</p>
       <p
@@ -531,15 +512,11 @@
       <p
         id='idm45159773195952'
       >...</p>
-      <div
-        data-list-type='bulleted'
-        data-type='list'
+      <ul
         id='idm45159773195392'
       >
-        <div
-          data-type='item'
-        >and item</div>
-      </div>
+        <li>and item</li>
+      </ul>
       <p>...</p>
       <p
         id='idm45159773193920'
@@ -564,14 +541,9 @@
         <div
           data-type='title'
         >and title</div>
-        <div
-          data-list-type='bulleted'
-          data-type='list'
-        >
-          <div
-            data-type='item'
-          >and item</div>
-        </div>
+        <ul>
+          <li>and item</li>
+        </ul>
       </div>
       <p>...</p>
       <p
@@ -600,20 +572,16 @@
       <p
         id='idm45159773185696'
       >...</p>
-      <div
+      <ul
         data-bullet-style='open-circle'
         data-element-type='LIST-TYPE'
         data-item-sep='[SEPARATOR]'
-        data-list-type='bulleted'
         data-mark-prefix='[PREFIX]'
         data-mark-suffix='[SUFFIX]'
-        data-type='list'
         id='idm45159773185136'
       >
-        <div
-          data-type='item'
-        >list with all attributes</div>
-      </div>
+        <li>list with all attributes</li>
+      </ul>
       <p>...</p>
       <p
         id='idm45159773181776'
@@ -643,20 +611,16 @@
         <div
           data-type='title'
         >list with all attributes and title</div>
-        <div
+        <ul
           data-bullet-style='open-circle'
           data-display='block'
           data-element-type='LIST-TYPE'
           data-item-sep='[SEPARATOR]'
-          data-list-type='bulleted'
           data-mark-prefix='[PREFIX]'
           data-mark-suffix='[SUFFIX]'
-          data-type='list'
         >
-          <div
-            data-type='item'
-          >and item</div>
-        </div>
+          <li>and item</li>
+        </ul>
       </div>
       <p>...</p>
       <p
@@ -698,15 +662,11 @@
       <p
         id='idm45159773166528'
       >...</p>
-      <div
-        data-list-type='enumerated'
-        data-type='list'
+      <ol
         id='idm45159773165968'
       >
-        <div
-          data-type='item'
-        >and item</div>
-      </div>
+        <li>and item</li>
+      </ol>
       <p>...</p>
       <p
         id='idm45159773164496'
@@ -731,14 +691,9 @@
         <div
           data-type='title'
         >and title</div>
-        <div
-          data-list-type='enumerated'
-          data-type='list'
-        >
-          <div
-            data-type='item'
-          >and item</div>
-        </div>
+        <ol>
+          <li>and item</li>
+        </ol>
       </div>
       <p>...</p>
       <p
@@ -767,22 +722,18 @@
       <p
         id='idm45159773156272'
       >...</p>
-      <div
+      <ol
         data-display='block'
         data-element-type='LIST-TYPE'
         data-item-sep='[SEPARATOR]'
-        data-list-type='enumerated'
         data-mark-prefix='[PREFIX]'
         data-mark-suffix='[SUFFIX]'
-        data-type='list'
         id='idm45159773155712'
         start='3'
         type='a'
       >
-        <div
-          data-type='item'
-        >list with all attributes</div>
-      </div>
+        <li>list with all attributes</li>
+      </ol>
       <p>...</p>
       <p
         id='idm45159773152080'
@@ -813,21 +764,17 @@
         <div
           data-type='title'
         >list with all attributes and title</div>
-        <div
+        <ol
           data-display='block'
           data-element-type='LIST-TYPE'
           data-item-sep='[SEPARATOR]'
-          data-list-type='enumerated'
           data-mark-prefix='[PREFIX]'
           data-mark-suffix='[SUFFIX]'
-          data-type='list'
           start='3'
           type='a'
         >
-          <div
-            data-type='item'
-          >and item</div>
-        </div>
+          <li>and item</li>
+        </ol>
       </div>
       <p>...</p>
       <p
@@ -867,16 +814,14 @@
       <p
         id='idm45159773137536'
       >...</p>
-      <div
-        data-list-type='labeled-item'
-        data-type='list'
+      <ul
+        data-labeled-item='true'
         id='idm45159773136976'
       >
-        <div
+        <li
           data-label='with a label'
-          data-type='item'
-        >and item</div>
-      </div>
+        >and item</li>
+      </ul>
       <p>...</p>
       <p
         id='idm45159773135040'

--- a/rhaptos/cnxmlutils/xsl/test/para.cnxml.html
+++ b/rhaptos/cnxmlutils/xsl/test/para.cnxml.html
@@ -166,15 +166,11 @@
   <p
     id='with-list'
   >foo</p>
-  <div
-    data-list-type='bulleted'
-    data-type='list'
+  <ul
     id='list1'
   >
-    <div
-      data-type='item'
-    >1</div>
-  </div>
+    <li>1</li>
+  </ul>
   <p
     id='with-figure'
   >foo</p>

--- a/rhaptos/cnxmlutils/xsl/test/title.cnxml
+++ b/rhaptos/cnxmlutils/xsl/test/title.cnxml
@@ -120,24 +120,7 @@
     <section id="pre-section">
       <!-- m46109 // 13c63123-7ecf-4a25-877f-b1468f34a303 -->
       <code id="coded" display="block">
-        <title>Formatting an Interrupt in Code Composer C</title>
-#pragma vector=PORT3_VECTOR
-    //compiler directive saying that this function should correspond with the port3 interrupt vector
-__interrupt void interruptHandle()
-{
-    //your ISR CODE
-}
-
-
-void main()
-{
-... all setup
-
-__enable_interrupt();
-    //Enables general maskable interrupts
-... the rest of your program
-}
-      </code>
+        <title>Formatting an Interrupt in Code Composer C</title></code>
       <!-- no c:preformat/c:title records exist in connextions-->
     </section>
 

--- a/rhaptos/cnxmlutils/xsl/test/title.cnxml.html
+++ b/rhaptos/cnxmlutils/xsl/test/title.cnxml.html
@@ -271,6 +271,7 @@ __enable_interrupt();
     //Enables general maskable interrupts
 ... the rest of your program
 }
+      
       </pre>
     </div>
 <!-- no c:preformat/c:title records exist in connextions-->

--- a/rhaptos/cnxmlutils/xsl/test/title.cnxml.html
+++ b/rhaptos/cnxmlutils/xsl/test/title.cnxml.html
@@ -254,25 +254,7 @@
       >Formatting an Interrupt in Code Composer C</div>
       <pre
         data-display='block'
-      >
-#pragma vector=PORT3_VECTOR
-    //compiler directive saying that this function should correspond with the port3 interrupt vector
-__interrupt void interruptHandle()
-{
-    //your ISR CODE
-}
-
-
-void main()
-{
-... all setup
-
-__enable_interrupt();
-    //Enables general maskable interrupts
-... the rest of your program
-}
-      
-      </pre>
+      ></pre>
     </div>
 <!-- no c:preformat/c:title records exist in connextions-->
   </section>

--- a/rhaptos/cnxmlutils/xsl/test/title.html
+++ b/rhaptos/cnxmlutils/xsl/test/title.html
@@ -255,24 +255,7 @@
       >Formatting an Interrupt in Code Composer C</div>
       <pre
         data-display='block'
-      >
-#pragma vector=PORT3_VECTOR
-    //compiler directive saying that this function should correspond with the port3 interrupt vector
-__interrupt void interruptHandle()
-{
-    //your ISR CODE
-}
-
-
-void main()
-{
-... all setup
-
-__enable_interrupt();
-    //Enables general maskable interrupts
-... the rest of your program
-}
-      </pre>
+      >xyz</pre>
     </div>
 <!-- no c:preformat/c:title records exist in connextions-->
   </section>

--- a/rhaptos/cnxmlutils/xsl/test/title.html.cnxml
+++ b/rhaptos/cnxmlutils/xsl/test/title.html.cnxml
@@ -200,24 +200,7 @@
         display='block'
         id='coded'
       >
-        <title>Formatting an Interrupt in Code Composer C</title>
-#pragma vector=PORT3_VECTOR
-    //compiler directive saying that this function should correspond with the port3 interrupt vector
-__interrupt void interruptHandle()
-{
-    //your ISR CODE
-}
-
-
-void main()
-{
-... all setup
-
-__enable_interrupt();
-    //Enables general maskable interrupts
-... the rest of your program
-}
-      
+        <title>Formatting an Interrupt in Code Composer C</title>xyz
       </code>
     </section>
     <quote

--- a/rhaptos/cnxmlutils/xsl/test/title.html.cnxml
+++ b/rhaptos/cnxmlutils/xsl/test/title.html.cnxml
@@ -217,6 +217,7 @@ __enable_interrupt();
     //Enables general maskable interrupts
 ... the rest of your program
 }
+      
       </code>
     </section>
     <quote


### PR DESCRIPTION
This is related to https://github.com/Connexions/cnx-recipes/issues/286 but does not quite fix the problem.

This makes our lists in general work better when there is no CSS. This makes the lists `a. foo bar` (instead of `1. foo bar`) but the STAAR format mentioned in the original Issue wants `A foo bar`.

/cc @helenemccarron 

# TODO

- [x] find out why a `<div>` is being generated for some lists in the TEA books
  - it is because the `<list>` is inside a `<para>` and that is not allowed in HTML (and will be fixed as part of #158)