### PR TITLE
convert windows ISO characters to UTF-8

### DIFF
--- a/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
+++ b/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
@@ -1686,4 +1686,17 @@
   </xsl:choose>
 </xsl:template>
 
+
+<!-- XHTML does not render Windows ISO characters at all.
+     See https://www.cs.tut.fi/~jkorpela/www/windows-chars.html for details and the conversion to UTF-8
+   -->
+<xsl:variable name="WINDOWS_ISO_CHARACTERS">&#130;&#131;&#132;&#133;&#134;&#135;&#136;&#137;&#138;&#139;&#140;&#145;&#146;&#147;&#148;&#149;&#150;&#151;&#152;&#153;&#154;&#155;&#156;&#159;</xsl:variable>
+<xsl:variable name="UTF8_CHARACTERS">&#8218;&#402;&#8222;&#8230;&#8224;&#8225;&#710;&#8240;&#352;&#8249;&#338;&#8216;&#8217;&#8220;&#8221;&#8226;&#8211;&#8212;&#732;&#8482;&#353;&#8250;&#339;&#376;</xsl:variable>
+
+<xsl:template match="text()">
+  <!-- translate($textString, "&#130;&#131;&#132;&#133;&#134;&#135;&#136;&#137;&#138;&#139;&#140;&#145;&#146;&#147;&#148;&#149;&#150;&#151;&#152;&#153;&#154;&#155;&#156;&#159;", "&#8218;&#402;&#8222;&#8230;&#8224;&#8225;&#710;&#8240;&#352;&#8249;&#338;&#8216;&#8217;&#8220;&#8221;&#8226;&#8211;&#8212;&#732;&#8482;&#353;&#8250;&#339;&#376;") -->
+  <xsl:variable name="textString" select="."/>
+  <xsl:value-of select="translate($textString, $WINDOWS_ISO_CHARACTERS, $UTF8_CHARACTERS)"/>
+</xsl:template>
+
 </xsl:stylesheet>

--- a/rhaptos/cnxmlutils/xsl/test/xhtml-characters.cnxml
+++ b/rhaptos/cnxmlutils/xsl/test/xhtml-characters.cnxml
@@ -1,0 +1,34 @@
+<?xml version="1.0"?>
+<document xmlns="http://cnx.rice.edu/cnxml" xmlns:md="http://cnx.rice.edu/mdml/0.4" xmlns:bib="http://bibtexml.sf.net/" xmlns:q="http://cnx.rice.edu/qml/1.0" xmlns:md1="http://cnx.rice.edu/mdml" xmlns:m="http://www.w3.org/1998/Math/MathML" id="id1164845029421" module-id="m12345" cnxml-version="0.7">
+<title>Document testing the use of the title tag</title>
+<content>
+  <para id="id1">XHTML does not render Windows ISO characters at all. See <link url="https://www.cs.tut.fi/~jkorpela/www/windows-chars.html">https://www.cs.tut.fi/~jkorpela/www/windows-chars.html</link> for details and the conversion to UTF-8</para>
+
+  <list id="list">
+  <item>&amp;#130; = &#130;</item>
+  <item>&amp;#131; = &#131;</item>
+  <item>&amp;#132; = &#132;</item>
+  <item>&amp;#133; = &#133;</item>
+  <item>&amp;#134; = &#134;</item>
+  <item>&amp;#135; = &#135;</item>
+  <item>&amp;#136; = &#136;</item>
+  <item>&amp;#137; = &#137;</item>
+  <item>&amp;#138; = &#138;</item>
+  <item>&amp;#139; = &#139;</item>
+  <item>&amp;#140; = &#140;</item>
+  <item>&amp;#145; = &#145;</item>
+  <item>&amp;#146; = &#146;</item>
+  <item>&amp;#147; = &#147;</item>
+  <item>&amp;#148; = &#148;</item>
+  <item>&amp;#149; = &#149;</item>
+  <item>&amp;#150; = &#150;</item>
+  <item>&amp;#151; = &#151;</item>
+  <item>&amp;#152; = &#152;</item>
+  <item>&amp;#153; = &#153;</item>
+  <item>&amp;#154; = &#154;</item>
+  <item>&amp;#155; = &#155;</item>
+  <item>&amp;#156; = &#156;</item>
+  <item>&amp;#159; = &#159;</item>
+  </list>
+</content>
+</document>

--- a/rhaptos/cnxmlutils/xsl/test/xhtml-characters.cnxml.html
+++ b/rhaptos/cnxmlutils/xsl/test/xhtml-characters.cnxml.html
@@ -1,0 +1,48 @@
+<body
+  xmlns='http://www.w3.org/1999/xhtml'
+  xmlns:bib='http://bibtexml.sf.net/'
+  xmlns:c='http://cnx.rice.edu/cnxml'
+  xmlns:data='http://www.w3.org/TR/html5/dom.html#custom-data-attribute'
+  xmlns:md='http://cnx.rice.edu/mdml'
+  xmlns:mod='http://cnx.rice.edu/#moduleIds'
+  xmlns:qml='http://cnx.rice.edu/qml/1.0'
+>
+  <div
+    data-type='document-title'
+  >Document testing the use of the title tag</div>
+  <p
+    id='id1'
+  >XHTML does not render Windows ISO characters at all. See
+    <a
+      href='https://www.cs.tut.fi/~jkorpela/www/windows-chars.html'
+    >https://www.cs.tut.fi/~jkorpela/www/windows-chars.html</a>for details and the conversion to UTF-8
+  </p>
+  <ul
+    id='list'
+  >
+    <li>&amp;#130; = &#8218;</li>
+    <li>&amp;#131; = &#402;</li>
+    <li>&amp;#132; = &#8222;</li>
+    <li>&amp;#133; = &#8230;</li>
+    <li>&amp;#134; = &#8224;</li>
+    <li>&amp;#135; = &#8225;</li>
+    <li>&amp;#136; = &#710;</li>
+    <li>&amp;#137; = &#8240;</li>
+    <li>&amp;#138; = &#352;</li>
+    <li>&amp;#139; = &#8249;</li>
+    <li>&amp;#140; = &#338;</li>
+    <li>&amp;#145; = &#8216;</li>
+    <li>&amp;#146; = &#8217;</li>
+    <li>&amp;#147; = &#8220;</li>
+    <li>&amp;#148; = &#8221;</li>
+    <li>&amp;#149; = &#8226;</li>
+    <li>&amp;#150; = &#8211;</li>
+    <li>&amp;#151; = &#8212;</li>
+    <li>&amp;#152; = &#732;</li>
+    <li>&amp;#153; = &#8482;</li>
+    <li>&amp;#154; = &#353;</li>
+    <li>&amp;#155; = &#8250;</li>
+    <li>&amp;#156; = &#339;</li>
+    <li>&amp;#159; = &#376;</li>
+  </ul>
+</body>


### PR DESCRIPTION
Refs https://github.com/Connexions/cnx-recipes/issues/312 .

This should solve the "Disappearing quotes and dashes" problem.

It turns out "Special" Windows characters were used in the source CNXML (likely from a Word import at some point). Browsers that are in HTML-rendering-mode gracefully convert them to UTF-8 but browsers that are in XHTML-rendering-mode are not so kind.

This converts those characters to their proper UTF-8 equivalents during the CNXML->HTML conversion.

See https://www.cs.tut.fi/~jkorpela/www/windows-chars.html for more details