### PR TITLE
Add cnxml->html image print-width attribute test

### DIFF
--- a/rhaptos/cnxmlutils/tests/data/media-image.cnxml
+++ b/rhaptos/cnxmlutils/tests/data/media-image.cnxml
@@ -26,6 +26,14 @@
         <caption></caption>
       </figure>
     </para>
+    <para id="id5432178901133">
+      <figure id="id1170343358770">
+        <media id="id1170343358770_media" alt="">
+          <image mime-type="image/jpg" src="graphics1.jpg" id="test_media_image_with_print_width" width="650" print-width="6.5in"/>
+        </media>
+        <caption>I know that’s what I said, but it’s not what I meant! </caption>
+      </figure>
+    </para>
     <para id="id1169517367733">
       <figure id="id2204878">
 	<!-- Optional attributes test case, except @for and @thumbnail -->

--- a/rhaptos/cnxmlutils/tests/test_xsl_cnxml_to_html5.py
+++ b/rhaptos/cnxmlutils/tests/test_xsl_cnxml_to_html5.py
@@ -196,6 +196,14 @@ class CnxmlToHtmlTestCase(unittest.TestCase):
                          namespaces={'h': html.nsmap[None]})[0]
         self.assertEqual(elm.attrib['alt'], "media alt")
 
+    def test_media_image_with_print_width(self):
+        cnxml = etree.parse(os.path.join(TEST_DATA_DIR, 'media-image.cnxml'))
+        html = self.call_target(cnxml).getroot()
+
+        elm = html.xpath("//h:img[@id='test_media_image_with_print_width']",
+                         namespaces={'h': html.nsmap[None]})[0]
+        self.assertEqual(elm.attrib['data-print-width'], "6.5in")
+
     def test_media_flash(self):
         # Case to test the conversion of c:media/c:flash transformation.
         cnxml = etree.parse(os.path.join(TEST_DATA_DIR, 'media-flash.cnxml'))


### PR DESCRIPTION
This is being moved from the in-database trigger transforms tests within cnx-db to this package.