### PR TITLE
Fix handling of nested terms in glossary

### DIFF
--- a/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
+++ b/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
@@ -1338,7 +1338,7 @@
   </dl>
 </xsl:template>
 
-<xsl:template match="c:definition//c:term">
+<xsl:template match="c:definition/c:term">
   <dt><xsl:apply-templates select="@*|node()"/></dt>
 </xsl:template>
 


### PR DESCRIPTION
The XPath `c:definition//c:term` matches _every_ `<term>` under `<definition>`, no matter how deeply nested, effectively producing incorrect HTML (`<dt>` within `<dt>`) if there are nested. This PR changes it to match just `<term>` directly under `<definition>`.

### Minimal examle

**Sample CNXML**

```xml
<?xml version="1.0"?>
<document xmlns="http://cnx.rice.edu/cnxml" id="new" cnxml-version="0.7" module-id="new">
    <title/>
    <content><para/></content>
    <glossary>
        <definition>
            <term>Before <term>within</term> after</term>
            <meaning/>
        </definition>
    </glossary>
</document>
```

**Before**

```xhtml
<div data-type="glossary">
    <h3 data-type="glossary-title">Glossary</h3>
    <dl>
        <dt>Before <dt>within</dt> after</dt>
        <dd/>
    </dl>
</div>
```

**After**

```xhtml
<div data-type="glossary">
    <h3 data-type="glossary-title">Glossary</h3>
    <dl>
        <dt>Before <span data-type="term">within</span> after</dt>
        <dd/>
    </dl>
</div>
```