### PR TITLE
use a `u` tag for double-underlined text

### DIFF
--- a/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
+++ b/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
@@ -843,11 +843,11 @@
 </xsl:template>
 
 <xsl:template match="c:emphasis[@effect='double-underline']">
-  <span data-type="emphasis">
+  <u data-type="emphasis">
     <xsl:call-template name="apply-template-no-selfclose">
       <xsl:with-param name="selection" select="@*|node()"/>
     </xsl:call-template>
-  </span>
+  </u>
 </xsl:template>
 
 <!-- ========================= -->

--- a/rhaptos/cnxmlutils/xsl/test/emphasis.cnxml.html
+++ b/rhaptos/cnxmlutils/xsl/test/emphasis.cnxml.html
@@ -40,10 +40,10 @@
       data-effect='normal'
       data-type='emphasis'
     >generic</span>brand.
-    <span 
+    <u 
       data-effect="double-underline" 
       data-type="emphasis"
-    >double underlined content</span>
+    >double underlined content</u>
   </p>
   <p
     id='broken-content'


### PR DESCRIPTION
refs #202 